### PR TITLE
Add crypto.hash polyfill to Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,24 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import crypto, { createHash } from 'node:crypto'
+import type { BinaryLike, BinaryToTextEncoding } from 'node:crypto'
+
+type HashFunction = (
+  algorithm: string,
+  data: BinaryLike,
+  encoding?: BinaryToTextEncoding,
+) => string | Buffer
+
+const cryptoWithHash = crypto as unknown as { hash?: HashFunction }
+
+if (typeof cryptoWithHash.hash !== 'function') {
+  cryptoWithHash.hash = (algorithm, data, encoding) => {
+    const hash = createHash(algorithm)
+    hash.update(data)
+    return encoding ? hash.digest(encoding) : hash.digest()
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- ensure the Vite config patches the Node crypto module with a hash helper when missing
- prevent startup failures on runtimes where `crypto.hash` is not provided

## Testing
- npm run build *(fails: existing TypeScript errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_68efdee228a48330b2d5b7b8fc52023f