### PR TITLE
[FIX]EPEFI-135:Se agregan coreeciones en vista responsive

### DIFF
--- a/src/components/admin/SearchAndFilter.tsx
+++ b/src/components/admin/SearchAndFilter.tsx
@@ -7,7 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Search, Filter, ArrowUpDown, Plus } from "lucide-react";
+import { Search, Filter, ArrowUpDown, Plus, User } from "lucide-react";
 import { CreateUserModal } from "../students/CreateUserModal";
 import { Button } from "@/components/ui/button";
 import type { StudentDB } from "@/types/types";
@@ -224,62 +224,105 @@ export const SearchAndFilter = ({
             </Select>
           )}
 
-          {filterOptions?.sortOptions &&
-            (currentFilters.sortBy ||
-              (hideUnsortedOption && "date")) && (
-            <Button
-              type="button"
-              variant="outline"
-              className="shrink-0 h-10 px-3"
-              onClick={handleSortDirectionToggle}
-              title={
-                (currentFilters.sortDirection ??
-                  defaultSortDirection(currentFilters.sortBy)) === "asc"
-                  ? "Orden ascendente"
-                  : "Orden descendente"
-              }
-            >
-              <ArrowUpDown className="w-4 h-4 mr-1.5" />
-              {(currentFilters.sortDirection ??
-                defaultSortDirection(currentFilters.sortBy)) === "asc"
-                ? "Asc"
-                : "Desc"}
-            </Button>
-          )}
-
-          {showClearFilters && (
-            <Button
-              type="button"
-              variant="ghost"
-              className="shrink-0 h-10 px-3"
-              onClick={handleClearFilters}
-            >
-              Limpiar filtros
-            </Button>
+          {/* Misma línea: Desc + Limpiar + Crear (mobile) */}
+          {(!!(
+            filterOptions?.sortOptions &&
+            (currentFilters.sortBy || (hideUnsortedOption && "date"))
+          ) ||
+            showClearFilters ||
+            (!hideCreateButton && onCreateNew)) && (
+            <div className="flex w-full min-w-0 flex-nowrap items-center gap-1.5 sm:w-auto sm:gap-2">
+              {filterOptions?.sortOptions &&
+                (currentFilters.sortBy ||
+                  (hideUnsortedOption && "date")) && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="shrink-0 h-10 px-2.5 sm:px-3"
+                    onClick={handleSortDirectionToggle}
+                    title={
+                      (currentFilters.sortDirection ??
+                        defaultSortDirection(currentFilters.sortBy)) === "asc"
+                        ? "Orden ascendente"
+                        : "Orden descendente"
+                    }
+                  >
+                    <ArrowUpDown className="w-4 h-4 mr-1" />
+                    {(currentFilters.sortDirection ??
+                      defaultSortDirection(currentFilters.sortBy)) === "asc"
+                      ? "Asc"
+                      : "Desc"}
+                  </Button>
+                )}
+              {showClearFilters && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="shrink-0 h-10 px-2 sm:px-3"
+                  onClick={handleClearFilters}
+                >
+                  <span className="sm:hidden">Limpiar</span>
+                  <span className="hidden sm:inline">Limpiar filtros</span>
+                </Button>
+              )}
+              {!hideCreateButton && onCreateNew && (
+                <div className="sm:hidden flex-1 min-w-0 ml-auto">
+                  {isStudentPage ? (
+                    <CreateUserModal onUserCreated={onCreateNew}>
+                      <Button
+                        className="cursor-pointer w-full justify-center px-4"
+                        data-tour="create-user"
+                      >
+                        <User className="w-4 h-4 mr-2" />
+                        Crear usuario
+                      </Button>
+                    </CreateUserModal>
+                  ) : (
+                    <Button
+                      onClick={() => onCreateNew?.()}
+                      className="cursor-pointer w-full justify-center px-4"
+                      data-tour="create-course"
+                    >
+                      <Plus className="w-4 h-4 mr-2" />
+                      {createButtonText}
+                    </Button>
+                  )}
+                </div>
+              )}
+            </div>
           )}
         </div>
       </div>
 
 
       {(extraActions || (!hideCreateButton && onCreateNew)) && (
-        <div className="flex flex-wrap items-center gap-2 w-full sm:w-auto shrink-0">
+        <div
+          className={`flex flex-wrap items-center gap-2 w-full sm:w-auto shrink-0 ${
+            !extraActions && !hideCreateButton && onCreateNew
+              ? "hidden sm:flex"
+              : ""
+          }`}
+        >
           {extraActions}
-          {!hideCreateButton && onCreateNew &&
-            (isStudentPage ? (
-              <CreateUserModal
-                onUserCreated={onCreateNew}
-                triggerText={createButtonText}
-              />
-            ) : (
-              <Button
-                onClick={() => onCreateNew?.()}
-                className="cursor-pointer"
-                data-tour="create-course"
-              >
-                <Plus className="w-4 h-4 mr-2 cursor-pointer" />
-                {createButtonText}
-              </Button>
-            ))}
+          {!hideCreateButton && onCreateNew && (
+            <div className={extraActions ? "hidden sm:block" : undefined}>
+              {isStudentPage ? (
+                <CreateUserModal
+                  onUserCreated={onCreateNew}
+                  triggerText={createButtonText}
+                />
+              ) : (
+                <Button
+                  onClick={() => onCreateNew?.()}
+                  className="cursor-pointer"
+                  data-tour="create-course"
+                >
+                  <Plus className="w-4 h-4 mr-2 cursor-pointer" />
+                  {createButtonText}
+                </Button>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/common/PaginationControls.tsx
+++ b/src/components/common/PaginationControls.tsx
@@ -8,6 +8,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { PaginationMeta } from "@/types/types";
 import type { RefObject } from "react";
 
@@ -44,25 +45,33 @@ export const PaginationControls = ({
   const visiblePages = getVisiblePages(currentPage, totalPages);
   const firstItem = pagination.total === 0 ? 0 : (currentPage - 1) * pagination.limit + 1;
   const lastItem = Math.min(currentPage * pagination.limit, pagination.total);
+  const canGoPrev = currentPage > 1;
+  const canGoNext = currentPage < totalPages;
+
   const scrollToTarget = () => {
     if (scrollTargetRef?.current) {
       scrollTargetRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   };
 
-  return (
-    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-      <p className="text-sm text-gray-600">
-        Mostrando {firstItem}-{lastItem} de {pagination.total}
-      </p>
+  const goToPage = (page: number) => {
+    onPageChange(page);
+    scrollToTarget();
+  };
 
-      <div className="flex items-center gap-4">
-        <div className="flex items-center gap-2">
-          <label htmlFor="pagination-limit" className="text-sm text-gray-600">
+  return (
+    <div className="flex w-full min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      {/* Desktop meta + limit */}
+      <div className="hidden sm:flex items-center gap-4">
+        <p className="text-sm text-gray-600 shrink-0">
+          Mostrando {firstItem}-{lastItem} de {pagination.total}
+        </p>
+        <div className="flex items-center gap-2 shrink-0">
+          <label htmlFor="pagination-limit-desktop" className="text-sm text-gray-600">
             Por página
           </label>
           <select
-            id="pagination-limit"
+            id="pagination-limit-desktop"
             className="h-9 rounded-md border border-gray-300 bg-white px-2 text-sm"
             value={pagination.limit}
             onChange={(e) => {
@@ -77,67 +86,123 @@ export const PaginationControls = ({
             ))}
           </select>
         </div>
-
-        <Pagination className="mx-0 w-auto">
-          <PaginationContent>
-            <PaginationItem>
-              <PaginationPrevious
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  if (currentPage > 1) {
-                    onPageChange(currentPage - 1);
-                    scrollToTarget();
-                  }
-                }}
-                className={currentPage === 1 ? "pointer-events-none opacity-50" : ""}
-              />
-            </PaginationItem>
-
-            {visiblePages.map((page, index) => {
-              const prev = visiblePages[index - 1];
-              const shouldShowEllipsis = prev && page - prev > 1;
-
-              return (
-                <Fragment key={`page-group-${page}`}>
-                  {shouldShowEllipsis && (
-                    <PaginationItem>
-                      <PaginationEllipsis />
-                    </PaginationItem>
-                  )}
-                  <PaginationItem>
-                    <PaginationLink
-                      href="#"
-                      isActive={page === currentPage}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        onPageChange(page);
-                        scrollToTarget();
-                      }}
-                    >
-                      {page}
-                    </PaginationLink>
-                  </PaginationItem>
-                </Fragment>
-              );
-            })}
-
-            <PaginationItem>
-              <PaginationNext
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  if (currentPage < totalPages) {
-                    onPageChange(currentPage + 1);
-                    scrollToTarget();
-                  }
-                }}
-                className={currentPage === totalPages ? "pointer-events-none opacity-50" : ""}
-              />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
       </div>
+
+      {/* Mobile: bloque único compacto */}
+      <div className="sm:hidden w-full rounded-xl border border-gray-200 bg-white overflow-hidden">
+        <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100 bg-gray-50/80">
+          <p className="text-xs text-gray-500 tabular-nums">
+            {firstItem}–{lastItem} de {pagination.total}
+          </p>
+          <div className="flex items-center gap-1.5">
+            <label htmlFor="pagination-limit-mobile" className="text-xs text-gray-500">
+              Por pág.
+            </label>
+            <select
+              id="pagination-limit-mobile"
+              className="h-7 rounded border border-gray-200 bg-white px-1.5 text-xs text-gray-700"
+              value={pagination.limit}
+              onChange={(e) => {
+                onLimitChange(Number(e.target.value));
+                scrollToTarget();
+              }}
+            >
+              {limitOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-[2.75rem_1fr_2.75rem] items-stretch">
+          <button
+            type="button"
+            disabled={!canGoPrev}
+            aria-label="Página anterior"
+            onClick={() => goToPage(currentPage - 1)}
+            className="flex h-11 items-center justify-center text-gray-700 hover:bg-gray-50 disabled:pointer-events-none disabled:opacity-30 transition-colors border-r border-gray-100"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+
+          <div className="flex flex-col items-center justify-center px-2 py-2">
+            <span className="text-sm font-semibold text-gray-900 tabular-nums leading-none">
+              {currentPage}
+              <span className="mx-1 font-normal text-gray-400">/</span>
+              {totalPages}
+            </span>
+            <span className="mt-0.5 text-[0.65rem] text-gray-400 leading-none">
+              página
+            </span>
+          </div>
+
+          <button
+            type="button"
+            disabled={!canGoNext}
+            aria-label="Página siguiente"
+            onClick={() => goToPage(currentPage + 1)}
+            className="flex h-11 items-center justify-center text-gray-700 hover:bg-gray-50 disabled:pointer-events-none disabled:opacity-30 transition-colors border-l border-gray-100"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Desktop: paginación numerada */}
+      <Pagination className="mx-0 hidden w-auto sm:flex">
+        <PaginationContent className="gap-1">
+          <PaginationItem>
+            <PaginationPrevious
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                if (canGoPrev) goToPage(currentPage - 1);
+              }}
+              className={!canGoPrev ? "pointer-events-none opacity-50" : ""}
+            />
+          </PaginationItem>
+
+          {visiblePages.map((page, index) => {
+            const prev = visiblePages[index - 1];
+            const shouldShowEllipsis = prev && page - prev > 1;
+
+            return (
+              <Fragment key={`page-group-${page}`}>
+                {shouldShowEllipsis && (
+                  <PaginationItem>
+                    <PaginationEllipsis />
+                  </PaginationItem>
+                )}
+                <PaginationItem>
+                  <PaginationLink
+                    href="#"
+                    isActive={page === currentPage}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      goToPage(page);
+                    }}
+                  >
+                    {page}
+                  </PaginationLink>
+                </PaginationItem>
+              </Fragment>
+            );
+          })}
+
+          <PaginationItem>
+            <PaginationNext
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                if (canGoNext) goToPage(currentPage + 1);
+              }}
+              className={!canGoNext ? "pointer-events-none opacity-50" : ""}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
     </div>
   );
 };

--- a/src/components/product/ConfirmDeleteModal.tsx
+++ b/src/components/product/ConfirmDeleteModal.tsx
@@ -23,23 +23,23 @@ interface Props {
 const ConfirmDeleteModal = ({ isOpen, onCancel, onConfirm, itemName, deleteLoading, id }: Props) => {
   return (
     <Dialog open={isOpen} onOpenChange={onCancel}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <AlertTriangle className="h-5 w-5 text-red-500" />
-            ¿Eliminar {itemName}?
+            <AlertTriangle className="h-5 w-5 text-red-500 shrink-0" />
+            <span className="break-words">¿Eliminar {itemName}?</span>
           </DialogTitle>
           <DialogDescription>
             Esta acción no se puede deshacer. El elemento será eliminado permanentemente.
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter className="flex gap-2 sm:gap-0">
+        <DialogFooter className="flex flex-col-reverse gap-2 sm:flex-row sm:gap-0">
           <Button
             type="button"
             variant="outline"
             onClick={onCancel}
             disabled={deleteLoading}
-            className="flex-1 sm:flex-none cursor-pointer"
+            className="w-full sm:w-auto cursor-pointer"
           >
             Cancelar
           </Button>
@@ -48,7 +48,7 @@ const ConfirmDeleteModal = ({ isOpen, onCancel, onConfirm, itemName, deleteLoadi
             variant="destructive"
             onClick={() => onConfirm(id)}
             disabled={deleteLoading}
-            className="flex-1 sm:flex-none cursor-pointer"
+            className="w-full sm:w-auto cursor-pointer"
           >
             {deleteLoading ? (
               <>

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -185,7 +185,7 @@ export const ProductList = ({ products, onProductUpdated }: ProductListProps) =>
             products.map((f) => (
               <li
                 key={f.id}
-                className="px-6 py-5 bg-white hover:bg-gray-50 border-b border-gray-200 transition-all duration-200"
+                className="px-4 py-4 sm:px-6 sm:py-5 bg-white hover:bg-gray-50 border-b border-gray-200 transition-all duration-200"
               >
                 <div className="flex flex-col sm:flex-row items-start gap-3 sm:gap-4">
                   {/* Imagen */}
@@ -209,14 +209,14 @@ export const ProductList = ({ products, onProductUpdated }: ProductListProps) =>
                             {f.titulo}
                           </Link>
                         </div>
-                        <div className="flex flex-wrap items-center gap-2 sm:gap-3 text-xs text-gray-500 mb-2">
-                          <span className="font-medium">📚 {f.materias?.length || 0} materias</span>
+                        <div className="flex flex-wrap items-center gap-2 sm:gap-3 text-sm text-gray-600 mb-2">
+                          <span className="font-medium">{f.materias?.length || 0} materias</span>
                         </div>
-                        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                          <p className="text-xs sm:text-sm text-gray-600 line-clamp-1 sm:line-clamp-1 flex-1 sm:mr-4">
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                          <p className="text-sm text-gray-700 line-clamp-2 flex-1 sm:mr-4">
                             {f.descripcion}
                           </p>
-                          <p className="text-base sm:text-lg font-bold text-gray-900 flex-shrink-0">
+                          <p className="text-lg font-bold text-gray-900 flex-shrink-0">
                             {formatCurrency(f.precio)}
                           </p>
                         </div>
@@ -255,7 +255,7 @@ export const ProductList = ({ products, onProductUpdated }: ProductListProps) =>
                         
                         <div 
                           data-tour="switch-toggle"
-                          className={`flex items-center gap-2 px-3 py-2 border rounded-lg transition-colors ${
+                          className={`flex items-center justify-between gap-2 px-3 py-2 border rounded-lg transition-colors w-full sm:w-auto ${
                             (f.estado === "activo")
                               ? 'bg-green-50 border-green-200' 
                               : 'bg-red-50 border-red-200'
@@ -267,7 +267,7 @@ export const ProductList = ({ products, onProductUpdated }: ProductListProps) =>
                             e.stopPropagation();
                           }}
                         >
-                          <span className={`text-xs whitespace-nowrap font-medium ${
+                          <span className={`text-sm font-medium ${
                             (f.estado === "activo")
                               ? 'text-green-700' 
                               : 'text-red-700'

--- a/src/components/students/StudentsList.tsx
+++ b/src/components/students/StudentsList.tsx
@@ -112,7 +112,7 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
       {selectedStudents.length > 0 && (
         <div className="flex flex-wrap items-center gap-2 px-4 py-3 bg-blue-50 border-b border-blue-100 text-sm">
           <Users className="w-4 h-4 text-blue-700 shrink-0" />
-          <span className="font-medium text-blue-900">
+          <span className="font-medium text-blue-900 flex-1 min-w-0">
             {selectedStudents.length} usuario{selectedStudents.length !== 1 ? "s" : ""} seleccionado
             {selectedStudents.length !== 1 ? "s" : ""}
           </span>
@@ -120,7 +120,7 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
             type="button"
             variant="outline"
             size="sm"
-            className="h-8 border-blue-200 text-blue-800 hover:bg-blue-100"
+            className="h-8 border-blue-200 text-blue-800 hover:bg-blue-100 w-full sm:w-auto"
             onClick={() => setSelectedRowIds([])}
           >
             Limpiar selección
@@ -128,7 +128,7 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
           <Button
             type="button"
             size="sm"
-            className="h-8 bg-blue-600 text-white hover:bg-blue-700"
+            className="h-8 bg-blue-600 text-white hover:bg-blue-700 w-full sm:w-auto"
             onClick={() => {
               setBulkSelectedCourseIds([]);
               setBulkAssignOpen(true);
@@ -142,7 +142,7 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
       )}
 
       {/* ── Vista mobile: tarjetas ── */}
-      <div className="block md:hidden divide-y divide-gray-100">
+      <div className="block md:hidden divide-y divide-gray-200 rounded-md border border-gray-200 bg-white shadow-sm overflow-hidden">
         {students.map((student, index) => (
           <div
             key={student.id || student.uid || `student-mobile-${index}`}
@@ -150,11 +150,11 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
           >
             {/* Cabecera: avatar + nombre + rol */}
             <div
-              className="flex items-center gap-3 cursor-pointer"
+              className="flex items-start gap-3 cursor-pointer"
               onClick={() => navigate(`/students/${student.id}`)}
             >
               <div
-                className="flex-shrink-0"
+                className="flex-shrink-0 pt-1"
                 onClick={(e) => e.stopPropagation()}
                 onMouseDown={(e) => e.stopPropagation()}
               >
@@ -169,41 +169,41 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
                   {student.nombre?.charAt(0).toUpperCase() || "?"}
                 </span>
               </div>
-              <div className="min-w-0">
-                <p className="font-semibold text-gray-900 truncate">{getFullName(student)}</p>
-                <p className="text-xs text-gray-500 truncate flex items-center gap-1 mt-0.5">
-                  <Mail className="w-3 h-3 flex-shrink-0" />
+              <div className="min-w-0 flex-1">
+                <p className="font-semibold text-gray-900 break-words">{getFullName(student)}</p>
+                <p className="text-sm text-gray-600 truncate flex items-center gap-1 mt-0.5">
+                  <Mail className="w-3.5 h-3.5 flex-shrink-0" />
                   {student.email || "Sin email"}
                 </p>
-              </div>
-              <div className="ml-auto flex items-center gap-1 flex-shrink-0">
-                {student.role?.admin && (
-                  <span className="px-2 py-0.5 text-[0.65rem] font-semibold rounded-full bg-purple-100 text-purple-800">
-                    Admin
-                  </span>
-                )}
-                {student.role?.student && (
-                  <span className="px-2 py-0.5 text-[0.65rem] font-semibold rounded-full bg-blue-100 text-blue-800">
-                    Alumno
-                  </span>
-                )}
+                <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+                  {student.role?.admin && (
+                    <span className="px-2 py-0.5 text-[0.65rem] font-semibold rounded-full bg-purple-100 text-purple-800">
+                      Admin
+                    </span>
+                  )}
+                  {student.role?.student && (
+                    <span className="px-2 py-0.5 text-[0.65rem] font-semibold rounded-full bg-blue-100 text-blue-800">
+                      Alumno
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
 
             {/* Acciones */}
-            <div className="mt-3 flex flex-wrap items-center gap-2">
+            <div className="mt-3 grid grid-cols-2 gap-2">
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => navigate(`/students/${student.id}`)}
-                className="h-8 flex-1 min-w-[100px] border-green-200 text-green-700 hover:bg-green-50 cursor-pointer"
+                className="h-9 w-full justify-center border-green-200 text-green-700 hover:bg-green-50 cursor-pointer"
                 data-tour="view-student-details"
               >
                 <Eye className="w-3.5 h-3.5 mr-1" />
-                Ver Detalles
+                Ver
               </Button>
 
-              <div className="flex-1 min-w-[80px]">
+              <div className="w-full">
                 <CreateUserModal
                   onUserCreated={onUserUpdated}
                   triggerText=""
@@ -213,7 +213,7 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
                   <Button
                     variant="outline"
                     size="sm"
-                    className="h-8 w-full border-blue-200 text-blue-700 hover:bg-blue-50 cursor-pointer"
+                    className="h-9 w-full justify-center border-blue-200 text-blue-700 hover:bg-blue-50 cursor-pointer"
                     data-tour="edit-student"
                   >
                     <Edit2 className="w-3.5 h-3.5 mr-1" />
@@ -231,7 +231,7 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
                   setSelectedCourseIds([]);
                   setAssignDialogOpen(true);
                 }}
-                className="h-8 flex-1 min-w-[80px] bg-blue-600 text-white hover:bg-blue-700 cursor-pointer disabled:opacity-50 disabled:pointer-events-none disabled:cursor-not-allowed"
+                className="h-9 w-full justify-center bg-blue-600 text-white hover:bg-blue-700 cursor-pointer disabled:opacity-50 disabled:pointer-events-none disabled:cursor-not-allowed"
                 title={
                   disableIndividualCursos
                     ? "Con la selección activa, usa «Asignar cursos al grupo» arriba."
@@ -245,7 +245,7 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
 
               {/* Toggle estado */}
               <div
-                className={`flex items-center gap-2 px-3 py-1.5 border rounded-lg transition-colors flex-1 min-w-[110px] ${
+                className={`flex items-center justify-between gap-2 px-3 py-1.5 border rounded-lg transition-colors min-h-9 ${
                   (student.activo ?? false)
                     ? 'bg-green-50 border-green-200'
                     : 'bg-red-50 border-red-200'
@@ -254,22 +254,22 @@ export function StudentList({ students, onUserUpdated, onStatusChange }: Student
                 onMouseDown={(e) => e.stopPropagation()}
                 data-tour="toggle-student-status"
               >
-                <span className={`text-xs font-medium whitespace-nowrap ${
+                <span className={`text-sm font-medium ${
                   (student.activo ?? false) ? 'text-green-700' : 'text-red-700'
                 }`}>
                   {updatingStatusId === student.id
-                    ? 'Actualizando...'
-                    : (student.activo ?? false) ? 'Habilitado' : 'Deshabilitado'}
+                    ? '...'
+                    : (student.activo ?? false) ? 'Activo' : 'Inactivo'}
                 </span>
                 {updatingStatusId === student.id ? (
-                  <Loader2 className="w-4 h-4 animate-spin text-gray-500 ml-auto" />
+                  <Loader2 className="w-4 h-4 animate-spin text-gray-500 shrink-0" />
                 ) : (
                   <Switch
                     checked={student.activo ?? false}
                     onCheckedChange={() => handleStatusChange(student.id, student.activo ?? false)}
                     onClick={(e) => e.stopPropagation()}
                     disabled={updatingStatusId !== null}
-                    className="ml-auto data-[state=checked]:bg-green-600 data-[state=unchecked]:bg-red-500 disabled:opacity-50"
+                    className="shrink-0 data-[state=checked]:bg-green-600 data-[state=unchecked]:bg-red-500 disabled:opacity-50"
                   />
                 )}
               </div>

--- a/src/components/subject/ModulesList.tsx
+++ b/src/components/subject/ModulesList.tsx
@@ -118,11 +118,11 @@ export const ModulesList = ({ modules, materiaId, onDelete, onEdit, defaultEnabl
                       </svg>
                     </div>
                     <div className="flex-1 min-w-0">
-                      <p className="text-lg font-semibold text-gray-900 transition-colors duration-200">
+                      <p className="text-base sm:text-lg font-semibold text-gray-900 transition-colors duration-200 break-words">
                         {m.titulo}
                       </p>
                       {m.descripcion && (
-                        <p className='text-sm text-gray-500 mt-1 line-clamp-2'>
+                        <p className="text-sm text-gray-600 mt-1 line-clamp-2">
                           {m.descripcion}
                         </p>
                       )}
@@ -168,22 +168,24 @@ export const ModulesList = ({ modules, materiaId, onDelete, onEdit, defaultEnabl
                   <div className="flex flex-col gap-1 w-full sm:w-auto">
                     {loadingExcepciones ? (
                       <div className="flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-md bg-gray-50 w-full sm:min-w-[180px]">
-                        <Loader2 className="w-4 h-4 animate-spin text-gray-500" />
-                        <span className="text-xs text-gray-600 whitespace-nowrap">Cargando...</span>
+                        <Loader2 className="w-4 h-4 animate-spin text-gray-500 shrink-0" />
+                        <span className="text-sm text-gray-600">Cargando...</span>
                       </div>
                     ) : (
                       <>
                         <div 
-                          className="flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-md bg-gray-50 w-full sm:min-w-[180px]"
+                          className="flex items-center justify-between gap-2 px-3 py-2 border border-gray-200 rounded-md bg-gray-50 w-full min-w-0 sm:min-w-[180px]"
                           onClick={(e) => e.stopPropagation()}
                           onMouseDown={(e) => e.stopPropagation()}
                         >
-                          <Users className="w-4 h-4 text-gray-500" />
-                          <span className="text-xs text-gray-600 whitespace-nowrap">
-                            {togglingModuleId === m.id ? 'Actualizando...' : 'Habilitado por defecto'}
-                          </span>
+                          <div className="flex items-center gap-2 min-w-0 flex-1">
+                            <Users className="w-4 h-4 text-gray-500 shrink-0" />
+                            <span className="text-sm text-gray-700 leading-tight">
+                              {togglingModuleId === m.id ? 'Actualizando...' : 'Habilitado por defecto'}
+                            </span>
+                          </div>
                           {togglingModuleId === m.id ? (
-                            <Loader2 className="w-4 h-4 animate-spin text-gray-500" />
+                            <Loader2 className="w-4 h-4 animate-spin text-gray-500 shrink-0" />
                           ) : (
                             <Switch
                               checked={moduleEnabledStates[m.id] !== undefined ? moduleEnabledStates[m.id] : (defaultEnabledByModule?.[m.id] ?? false)}
@@ -194,7 +196,7 @@ export const ModulesList = ({ modules, materiaId, onDelete, onEdit, defaultEnabl
                                 e.stopPropagation();
                               }}
                               disabled={togglingModuleId !== null}
-                              className="data-[state=checked]:bg-green-600 data-[state=unchecked]:bg-red-500 disabled:opacity-50"
+                              className="shrink-0 data-[state=checked]:bg-green-600 data-[state=unchecked]:bg-red-500 disabled:opacity-50"
                             />
                           )}
                         </div>
@@ -204,14 +206,14 @@ export const ModulesList = ({ modules, materiaId, onDelete, onEdit, defaultEnabl
                           <Button
                             variant="outline"
                             size="sm"
-                            className="h-auto min-h-8 w-full text-left text-amber-700 border-amber-300 bg-amber-50 hover:bg-amber-100 hover:border-amber-400 whitespace-normal"
+                            className="h-auto min-h-8 w-full justify-center sm:justify-start text-amber-700 border-amber-300 bg-amber-50 hover:bg-amber-100 hover:border-amber-400 whitespace-normal"
                             onClick={(e) => e.stopPropagation()}
                           >
-                            <UserMinus className="w-4 h-4 mr-1.5" />
+                            <UserMinus className="w-4 h-4 mr-1.5 shrink-0" />
                             {moduloExcepciones[m.id].length} estudiante{moduloExcepciones[m.id].length !== 1 ? 's' : ''} no habilitado{moduloExcepciones[m.id].length !== 1 ? 's' : ''}
                           </Button>
                         </PopoverTrigger>
-                        <PopoverContent className="w-80" align="end" onClick={(e) => e.stopPropagation()}>
+                        <PopoverContent className="w-[calc(100vw-2rem)] max-w-80 sm:w-80" align="end" onClick={(e) => e.stopPropagation()}>
                           <p className="font-medium text-amber-800 mb-2">Estudiantes sin este módulo habilitado</p>
                           <p className="text-sm text-gray-600 mb-2">
                             Los siguientes tienen este módulo deshabilitado individualmente:

--- a/src/components/subject/SubjectList.tsx
+++ b/src/components/subject/SubjectList.tsx
@@ -95,11 +95,11 @@ export const SubjectList = ({ subjects, onEdit, onUnassign, showUnassign = false
                     <div className="flex-1 min-w-0">
                       <Link
                         to={`/subjects/${encodeURIComponent(m.id)}`}
-                        className="text-lg font-semibold text-gray-900 hover:text-[#7a1a3a] hover:underline transition-colors duration-200 block"
+                        className="text-base sm:text-lg font-semibold text-gray-900 hover:text-[#7a1a3a] hover:underline transition-colors duration-200 block break-words"
                       >
                         {m.nombre}
                       </Link>
-                      <p className='text-sm text-gray-500 mt-1'>
+                      <p className="text-sm text-gray-600 mt-1">
                         {m.modulos ? m.modulos.length : 0} {m.modulos && m.modulos.length !== 1 ? 'módulos' : 'módulo'}
                       </p>
                     </div>
@@ -153,11 +153,17 @@ export const SubjectList = ({ subjects, onEdit, onUnassign, showUnassign = false
                     </Button>
                   )}
                   <div 
-                    className="flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-md bg-gray-50 w-full sm:w-auto"
+                    className={`flex items-center justify-between gap-2 px-3 py-2 border rounded-md w-full sm:w-auto ${
+                      isSubjectActive(m)
+                        ? "bg-green-50 border-green-200"
+                        : "bg-red-50 border-red-200"
+                    }`}
                     onClick={(e) => e.stopPropagation()}
                     onMouseDown={(e) => e.stopPropagation()}
                   >
-                    <span className="text-xs text-gray-600 whitespace-nowrap">
+                    <span className={`text-sm font-medium ${
+                      isSubjectActive(m) ? "text-green-700" : "text-red-700"
+                    }`}>
                       {updatingStatusId === m.id ? 'Actualizando...' : (isSubjectActive(m) ? 'Activo' : 'Inactivo')}
                     </span>
                     {updatingStatusId === m.id ? (

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100vw-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100vw-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -65,13 +65,13 @@ const PaginationPrevious = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to previous page"
+    aria-label="Página anterior"
     size="default"
-    className={cn("gap-1 pl-2.5", className)}
+    className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
     {...props}
   >
     <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
+    <span className="hidden sm:inline">Anterior</span>
   </PaginationLink>
 )
 PaginationPrevious.displayName = "PaginationPrevious"
@@ -81,12 +81,12 @@ const PaginationNext = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to next page"
+    aria-label="Página siguiente"
     size="default"
-    className={cn("gap-1 pr-2.5", className)}
+    className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
     {...props}
   >
-    <span>Next</span>
+    <span className="hidden sm:inline">Siguiente</span>
     <ChevronRight className="h-4 w-4" />
   </PaginationLink>
 )

--- a/src/pages/CompletedExams.tsx
+++ b/src/pages/CompletedExams.tsx
@@ -314,29 +314,29 @@ export default function CompletedExams() {
         <p className="text-center text-red-600 py-6">{error}</p>
       ) : items.length > 0 ? (
         <>
-          <div className="block md:hidden divide-y divide-gray-200 rounded-md border bg-white">
+          <div className="block md:hidden divide-y divide-gray-200 rounded-md border border-gray-200 bg-white shadow-sm">
             {items.map((row) => (
-              <div key={row.id} className="p-4 space-y-3">
-                <div className="min-w-0 space-y-1">
-                  <p className="font-semibold text-gray-900 break-words">
+              <div key={row.id} className="p-4 space-y-3 bg-white">
+                <div className="min-w-0 space-y-1.5">
+                  <p className="font-semibold text-gray-900 break-words text-base">
                     {row.nombreAlumno || "—"}
                   </p>
-                  <p className="text-sm text-gray-600 break-words">
+                  <p className="text-sm text-gray-700 break-words">
                     {row.tituloFormacion ||
                       coursesById[row.idFormacion]?.titulo ||
                       row.idFormacion}
                   </p>
-                  <p className="text-sm text-gray-500 break-words">
+                  <p className="text-sm text-gray-600 break-words">
                     {row.tituloExamen ||
                       examsById[row.idExamen]?.titulo ||
                       row.idExamen}
                   </p>
-                  <div className="flex flex-wrap items-center gap-2 pt-1">
-                    <span className="text-sm font-medium text-gray-900">
+                  <div className="flex flex-wrap items-center justify-between gap-2 pt-1">
+                    <span className="text-sm font-semibold text-gray-900">
                       Nota: {typeof row.nota === "number" ? row.nota : "—"}
                     </span>
                     <span
-                      className={`inline-flex px-2 py-0.5 text-xs font-semibold rounded-full ${
+                      className={`inline-flex px-2.5 py-0.5 text-xs font-semibold rounded-full ${
                         row.aprobado
                           ? "bg-green-100 text-green-800"
                           : "bg-red-100 text-red-800"
@@ -345,7 +345,7 @@ export default function CompletedExams() {
                       {row.aprobado ? "Aprobado" : "No aprobado"}
                     </span>
                   </div>
-                  <p className="text-xs text-gray-400">
+                  <p className="text-xs text-gray-500">
                     {formatTimestamp(row.fechaRealizacion)}
                   </p>
                 </div>

--- a/src/pages/CreateExam.tsx
+++ b/src/pages/CreateExam.tsx
@@ -391,7 +391,7 @@ export default function CreateExam() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between gap-3">
-        <Button type="button" variant="outline" onClick={() => navigate("/exams")}>
+        <Button type="button" variant="outline" className="w-full sm:w-auto" onClick={() => navigate("/exams")}>
           <ArrowLeft className="w-4 h-4 mr-2" />
           Volver a Exámenes
         </Button>
@@ -577,22 +577,22 @@ export default function CreateExam() {
             <div
               role="toolbar"
               aria-label="Acciones de preguntas"
-              className="fixed z-40 bottom-6 -translate-x-1/2 transition-[left] duration-300"
+              className="fixed z-40 bottom-4 -translate-x-1/2 sm:bottom-6 max-w-[calc(100vw-2rem)] transition-[left] duration-300"
               style={{ left: `calc(50vw + ${sidebarWidth / 2}px)` }}
             >
               <div className="rounded-xl border border-border bg-background/95 backdrop-blur-sm shadow-lg p-2">
-                <Button type="button" onClick={addQuestion} className="shadow-sm">
+                <Button type="button" onClick={addQuestion} className="shadow-sm w-full sm:w-auto justify-center">
                   <Plus className="w-4 h-4 mr-2" />
                   Agregar pregunta
                 </Button>
               </div>
             </div>
 
-            <div className="flex justify-end gap-2 pb-20">
-              <Button type="button" variant="outline" onClick={() => navigate("/exams")}>
+            <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pb-24 sm:pb-20">
+              <Button type="button" variant="outline" className="w-full sm:w-auto" onClick={() => navigate("/exams")}>
                 Cancelar
               </Button>
-              <Button type="submit" disabled={!canSave}>
+              <Button type="submit" disabled={!canSave} className="w-full sm:w-auto">
                 <Save className="w-4 h-4 mr-2" />
                 {saving
                   ? "Guardando..."

--- a/src/pages/CreateProduct.tsx
+++ b/src/pages/CreateProduct.tsx
@@ -313,7 +313,7 @@ export default function CreateProduct() {
   const handleBack = () => { if (currentTab > 0) setCurrentTab(currentTab - 1) };
 
   return (
-    <div className="space-y-6 max-w-4xl mx-auto p-4">
+    <div className="space-y-6 max-w-4xl mx-auto">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
         <Link to="/products" className="shrink-0">
           <Button
@@ -448,12 +448,13 @@ export default function CreateProduct() {
             </CardContent>
           </Card>
 
-          <div className="flex justify-between pt-4">
+          <div className="flex flex-col-reverse gap-2 pt-4 sm:flex-row sm:justify-between">
             <Button
               type="button"
               variant="outline"
               onClick={handleBack}
               disabled={currentTab === 0 || loading || currentTab === 2 && !createdCourseId}
+              className="w-full sm:w-auto"
             >
               <ArrowLeft className="w-4 h-4 mr-2" />
               Anterior
@@ -462,7 +463,7 @@ export default function CreateProduct() {
             {currentTab === 0 ? (
               <Button
                 type="button"
-                className="cursor-pointer"
+                className="cursor-pointer w-full sm:w-auto"
                 onClick={async () => {
                   // Si el curso ya está creado, solo avanzar
                   if (createdCourseId && courseAlreadyCreatedInSession) {
@@ -504,7 +505,7 @@ export default function CreateProduct() {
                 )}
               </Button>
             ) : (
-              <Button type="button" onClick={finalizeCourse} disabled={loading}>
+              <Button type="button" onClick={finalizeCourse} disabled={loading} className="w-full sm:w-auto">
                 {loading ? (
                   <>
                     <Loader2 className="w-4 h-4 mr-2 animate-spin" />

--- a/src/pages/EditProduct.tsx
+++ b/src/pages/EditProduct.tsx
@@ -437,7 +437,7 @@ export default function EditProduct() {
   }
 
   return (
-    <div className="space-y-6 max-w-4xl mx-auto p-4">
+    <div className="space-y-6 max-w-4xl mx-auto">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
         <Link to="/products" className="shrink-0">
           <Button variant="outline" size="sm" className="flex items-center space-x-2 cursor-pointer w-full sm:w-auto">
@@ -485,7 +485,7 @@ export default function EditProduct() {
       <Form {...form}>
         <div className="border-b border-gray-200">
           <div className="flex flex-col gap-3 pb-2 sm:flex-row sm:items-center sm:justify-between">
-            <nav className="flex space-x-1 overflow-x-auto scrollbar-hide">
+            <nav className="flex space-x-1 overflow-x-auto scrollbar-hide min-w-0">
               {tabs.map((tab, index) => (
                 <button
                   key={tab.id}
@@ -601,13 +601,13 @@ export default function EditProduct() {
             </CardContent>
           </Card>
 
-          <div className="flex justify-between pt-4">
+          <div className="flex flex-col-reverse gap-2 pt-4 sm:flex-row sm:justify-between">
             <Button
               type="button"
               variant="outline"
               onClick={handleBack}
               disabled={currentTab === 0 || loading}
-              className="cursor-pointer"
+              className="cursor-pointer w-full sm:w-auto"
             >
               <ArrowLeft className="w-4 h-4 mr-2" />
               Anterior
@@ -616,7 +616,7 @@ export default function EditProduct() {
             {currentTab === 0 ? (
               <Button
                 type="button"
-                className="cursor-pointer"
+                className="cursor-pointer w-full sm:w-auto"
                 onClick={async () => {
                   const isValid = await form.trigger();
                   if (!isValid) {
@@ -651,7 +651,7 @@ export default function EditProduct() {
               </Button>
             ) : (
               <Button 
-                className="cursor-pointer" 
+                className="cursor-pointer w-full sm:w-auto" 
                 onClick={async () => {
                   const currentData = form.getValues();
                   

--- a/src/pages/Exams.tsx
+++ b/src/pages/Exams.tsx
@@ -206,24 +206,24 @@ export default function Exams() {
             <div className="block md:hidden divide-y divide-gray-200 rounded-md border bg-white">
               {exams.map((exam, index) => (
                 <div key={exam.id} className="p-4 space-y-3">
-                  <div className="min-w-0">
-                    <p className="font-semibold text-gray-900 break-words">
+                  <div className="min-w-0 space-y-1.5">
+                    <p className="font-semibold text-gray-900 break-words text-base">
                       {exam.titulo || `Examen ${index + 1}`}
                     </p>
-                    <p className="text-sm text-gray-500 mt-1 break-words">
+                    <p className="text-sm text-gray-600 break-words">
                       {coursesById[exam.idFormacion]?.titulo || exam.idFormacion}
                     </p>
-                    <p className="text-xs text-gray-400 mt-1">
+                    <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-sm font-medium text-gray-700">
                       {exam.preguntas?.length ?? 0} pregunta
                       {(exam.preguntas?.length ?? 0) !== 1 ? "s" : ""}
-                    </p>
+                    </span>
                   </div>
                   <div className="flex flex-wrap gap-2">
                     <Button
                       type="button"
                       variant="outline"
                       size="sm"
-                      className="cursor-pointer flex-1 min-w-[7rem]"
+                      className="cursor-pointer flex-1 min-w-[7rem] justify-center"
                       onClick={() =>
                         navigate(`/exams/${encodeURIComponent(exam.id)}/edit`)
                       }
@@ -235,7 +235,7 @@ export default function Exams() {
                       type="button"
                       variant="outline"
                       size="sm"
-                      className="cursor-pointer flex-1 min-w-[7rem] text-red-600 border-red-200 hover:bg-red-50 hover:text-red-700"
+                      className="cursor-pointer flex-1 min-w-[7rem] justify-center text-red-600 border-red-200 hover:bg-red-50 hover:text-red-700"
                       onClick={() => handleDeleteClick(exam.id)}
                     >
                       <Trash2 className="w-4 h-4 mr-1" />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,7 +29,7 @@ const Index = () => {
       <SidebarLayoutProvider>
       <div className="min-h-screen bg-gray-50 flex">
         <AdminSidebar isOpen={isSidebarOpen} onToggle={setIsSidebarOpen} />
-      <main className="flex-1 p-4 lg:p-8 overflow-auto">
+      <main className="flex-1 min-w-0 p-4 lg:p-8 overflow-x-hidden overflow-y-auto">
         {/* Header móvil */}
         <div className="lg:hidden mb-6 flex items-center justify-between">
           <h1 className="text-xl font-semibold text-gray-900">EPEFI Admin</h1>

--- a/src/pages/StudentDetail.tsx
+++ b/src/pages/StudentDetail.tsx
@@ -335,14 +335,14 @@ export const StudentDetail = () => {
     if (!student) return <div className="p-6">No se encontró el estudiante</div>;
 
     return (
-        <div className="space-y-6 max-w-7xl mx-auto p-4">
+        <div className="space-y-6 max-w-7xl mx-auto">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                <div className="flex items-center space-x-4">
-                    <Button variant="outline" size="sm" onClick={() => navigate(-1)} className='cursor-pointer'>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center min-w-0">
+                    <Button variant="outline" size="sm" onClick={() => navigate(-1)} className="cursor-pointer w-full sm:w-auto shrink-0">
                         <ArrowLeft className="w-4 h-4 mr-2" />
                         Volver
                     </Button>
-                    <h1 className="text-lg sm:text-3xl font-bold text-gray-900 leading-tight">{student.nombre} {student.apellido}</h1>
+                    <h1 className="text-xl sm:text-3xl font-bold text-gray-900 leading-tight break-words min-w-0">{student.nombre} {student.apellido}</h1>
                 </div>
                 <div onClick={(e) => e.stopPropagation()}>
                     <CreateUserModal
@@ -363,7 +363,7 @@ export const StudentDetail = () => {
                         <Button
                             variant="outline"
                             size="sm"
-                            className="h-9 px-3 border-blue-200 text-blue-700 hover:bg-blue-50 hover:border-blue-300 hover:text-blue-800 transition-all duration-200 shadow-sm cursor-pointer"
+                            className="h-9 px-3 w-full sm:w-auto justify-center border-blue-200 text-blue-700 hover:bg-blue-50 hover:border-blue-300 hover:text-blue-800 transition-all duration-200 shadow-sm cursor-pointer"
                             title="Editar usuario"
                         >
                             <Edit2 className="w-4 h-4 mr-1.5" />

--- a/src/pages/SubjectDetail.tsx
+++ b/src/pages/SubjectDetail.tsx
@@ -216,14 +216,14 @@ export const SubjectDetail = () => {
     if (!materia) return <div className="p-6">No se encontró el curso</div>;
 
     return (
-        <div className="space-y-6 max-w-5xl mx-auto p-4">
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-                <div className="flex items-center space-x-4">
-                    <Button variant="outline" size="sm" onClick={() => navigate(-1)} className='cursor-pointer'>
+        <div className="space-y-6 max-w-5xl mx-auto">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center min-w-0">
+                    <Button variant="outline" size="sm" onClick={() => navigate(-1)} className="cursor-pointer w-full sm:w-auto shrink-0">
                         <ArrowLeft className="w-4 h-4 mr-2" />
                         Volver
                     </Button>
-                    <h1 className="text-3xl font-bold text-gray-900">{materia.nombre}</h1>
+                    <h1 className="text-xl sm:text-3xl font-bold text-gray-900 break-words min-w-0">{materia.nombre}</h1>
                 </div>
             </div>
 


### PR DESCRIPTION
Ticket: EPEFI-135

## Qué y por qué

En mobile el admin seguía con overflow, listas poco legibles y acciones (crear / paginado / filtros) mal acomodadas; se corrigió con layout responsive compartido (SearchAndFilter, PaginationControls, diálogos y listas) vía breakpoints sm:/md: para no tocar desktop, en lugar de CSS o pantallas nuevas por módulo

## Qué puede romper

No romperia nada 

## Capturas
<img width="492" height="937" alt="image" src="https://github.com/user-attachments/assets/87947b36-5963-494b-9070-2fce0036cae9" />
<img width="453" height="925" alt="image" src="https://github.com/user-attachments/assets/8eef73bf-497d-4a1a-a8e9-b0e20e244e0b" />
<img width="491" height="943" alt="image" src="https://github.com/user-attachments/assets/5fc05021-6050-4cc3-8794-bff8811d5c8b" />

<!-- Capturas de la UI si es el cambio fue en el frontend. Si es backend: el response, el log o la query con su resultado. -->
