### PR TITLE
FEAT-EPEFI-137-PUNTAJES-PREGUNTAS

### DIFF
--- a/src/pages/CompletedExamDetail.tsx
+++ b/src/pages/CompletedExamDetail.tsx
@@ -16,6 +16,12 @@ import {
   buildCompletedExamQuestions,
   normalizeAnswerIds,
 } from "@/utils/completedExamDetail";
+import {
+  computeNotaFromPorcentaje,
+  computePorcentajeFromPuntos,
+  PUNTOS_TOTAL_EXAMEN,
+  sumPreguntasPuntosObtenidos,
+} from "@/utils/examPoints";
 import { formatTimestamp } from "@/utils/formatTimestamp";
 import {
   COMPLETED_EXAMS_LIST_PATH,
@@ -31,6 +37,10 @@ type DetailState = {
   nota: number;
   aprobado: boolean;
   fechaRealizacion?: FirestoreTimestamp | string | number;
+  intentoNumero?: number;
+  totalIntentos?: number;
+  porcentajeAciertos?: number;
+  puntosObtenidos?: number;
 };
 
 export default function CompletedExamDetail() {
@@ -63,14 +73,34 @@ export default function CompletedExamDetail() {
 
         const merged = buildCompletedExamQuestions(data, raw, exam);
         setPreguntas(merged);
+
+        const puntosFromQuestions = sumPreguntasPuntosObtenidos(merged);
+        const puntosObtenidos =
+          typeof data.puntosObtenidos === "number"
+            ? data.puntosObtenidos
+            : puntosFromQuestions;
+        const porcentajeAciertos =
+          typeof data.porcentajeAciertos === "number"
+            ? data.porcentajeAciertos
+            : computePorcentajeFromPuntos(puntosObtenidos);
+        const nota =
+          typeof data.nota === "number"
+            ? data.nota
+            : computeNotaFromPorcentaje(porcentajeAciertos);
+        const aprobado = porcentajeAciertos >= 70;
+
         setMeta({
           id: data.id,
           nombreAlumno: data.nombreAlumno,
           idFormacion: data.idFormacion,
           idExamen: data.idExamen,
-          nota: data.nota,
-          aprobado: data.aprobado,
+          nota,
+          aprobado,
           fechaRealizacion: data.fechaRealizacion,
+          intentoNumero: data.intentoNumero,
+          totalIntentos: data.totalIntentos,
+          porcentajeAciertos,
+          puntosObtenidos,
         });
 
         const course = data.idFormacion
@@ -153,6 +183,32 @@ export default function CompletedExamDetail() {
             </span>
           </div>
           <div>
+            <span className="text-muted-foreground">Puntos obtenidos: </span>
+            <span className="font-medium">
+              {typeof meta.puntosObtenidos === "number"
+                ? `${meta.puntosObtenidos} / ${PUNTOS_TOTAL_EXAMEN}`
+                : "—"}
+            </span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Porcentaje de aciertos: </span>
+            <span className="font-medium">
+              {typeof meta.porcentajeAciertos === "number"
+                ? `${meta.porcentajeAciertos}%`
+                : "—"}
+            </span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Intento: </span>
+            <span className="font-medium">
+              {typeof meta.intentoNumero === "number"
+                ? meta.totalIntentos != null
+                  ? `${meta.intentoNumero} de ${meta.totalIntentos}`
+                  : meta.intentoNumero
+                : "—"}
+            </span>
+          </div>
+          <div>
             <span className="text-muted-foreground">Estado: </span>
             <Badge variant={meta.aprobado ? "default" : "destructive"}>
               {meta.aprobado ? "Aprobado" : "No aprobado"}
@@ -182,13 +238,24 @@ export default function CompletedExamDetail() {
               normalizeAnswerIds(q.respuestasSeleccionadas)
             );
             const correctOptions = q.respuestas.filter((r) => r.esCorrecta);
+            const puntosObtenidos =
+              typeof q.puntosObtenidos === "number" ? q.puntosObtenidos : 0;
 
             return (
               <Card key={q.id || index}>
                 <CardHeader className="pb-2 space-y-2">
-                  <CardTitle className="text-base leading-snug">
-                    Pregunta {index + 1}
-                  </CardTitle>
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <CardTitle className="text-base leading-snug">
+                      Pregunta {index + 1}
+                    </CardTitle>
+                    {typeof q.puntos === "number" && (
+                      <Badge
+                        variant={puntosObtenidos > 0 ? "default" : "secondary"}
+                      >
+                        {puntosObtenidos} / {q.puntos} pts
+                      </Badge>
+                    )}
+                  </div>
                   <p className="text-sm font-normal text-foreground">{q.texto}</p>
                 </CardHeader>
                 <CardContent>

--- a/src/pages/CreateExam.tsx
+++ b/src/pages/CreateExam.tsx
@@ -20,6 +20,11 @@ import { ExamsAPI } from "@/service/exams";
 import type { Course, Examen, ExamenCreatePayload } from "@/types/types";
 import { toast } from "sonner";
 import { useSidebarLayout } from "@/context/SidebarLayoutContext";
+import {
+  distributePuntosEqually,
+  PUNTOS_TOTAL_EXAMEN,
+  sumPreguntasPuntos,
+} from "@/utils/examPoints";
 
 type OptionForm = {
   id: string;
@@ -30,12 +35,14 @@ type OptionForm = {
 type QuestionForm = {
   id: string;
   texto: string;
+  puntos: number;
   respuestas: OptionForm[];
 };
 
 type QuestionError = {
   texto?: string;
   respuestas?: string;
+  puntos?: string;
 };
 
 type ValidationResult = {
@@ -57,32 +64,49 @@ const createEmptyOption = (): OptionForm => ({
 const createEmptyQuestion = (): QuestionForm => ({
   id: makeId(),
   texto: "",
+  puntos: PUNTOS_TOTAL_EXAMEN,
   respuestas: [createEmptyOption(), createEmptyOption()],
 });
+
+const applyEqualPuntos = (questions: QuestionForm[]): QuestionForm[] => {
+  const distribution = distributePuntosEqually(questions.length);
+  return questions.map((question, index) => ({
+    ...question,
+    puntos: distribution[index] ?? 0,
+  }));
+};
 
 function examToFormState(exam: Examen): {
   title: string;
   idFormacion: string;
   questions: QuestionForm[];
 } {
+  const rawQuestions =
+    exam.preguntas?.length > 0
+      ? exam.preguntas.map((q) => ({
+          id: q.id || makeId(),
+          texto: q.texto || "",
+          puntos: typeof q.puntos === "number" ? q.puntos : 0,
+          respuestas:
+            q.respuestas?.length > 0
+              ? q.respuestas.map((r) => ({
+                  id: r.id || makeId(),
+                  texto: r.texto || "",
+                  esCorrecta: Boolean(r.esCorrecta),
+                }))
+              : [createEmptyOption(), createEmptyOption()],
+        }))
+      : [createEmptyQuestion()];
+
+  const hasAllPuntos = rawQuestions.every((q) => q.puntos > 0);
+  const questions = hasAllPuntos
+    ? rawQuestions
+    : applyEqualPuntos(rawQuestions);
+
   return {
     title: exam.titulo || "",
     idFormacion: exam.idFormacion || "",
-    questions:
-      exam.preguntas?.length > 0
-        ? exam.preguntas.map((q) => ({
-            id: q.id || makeId(),
-            texto: q.texto || "",
-            respuestas:
-              q.respuestas?.length > 0
-                ? q.respuestas.map((r) => ({
-                    id: r.id || makeId(),
-                    texto: r.texto || "",
-                    esCorrecta: Boolean(r.esCorrecta),
-                  }))
-                : [createEmptyOption(), createEmptyOption()],
-          }))
-        : [createEmptyQuestion()],
+    questions,
   };
 }
 
@@ -103,6 +127,7 @@ export default function CreateExam() {
   const [formationError, setFormationError] = useState("");
   const [questionsError, setQuestionsError] = useState("");
   const [questionErrors, setQuestionErrors] = useState<Record<string, QuestionError>>({});
+  const [puntosError, setPuntosError] = useState("");
   const lastQuestionRef = useRef<HTMLDivElement | null>(null);
   const scrollToNewQuestion = useRef(false);
   const fieldRefs = useRef<Record<string, HTMLElement | null>>({});
@@ -185,13 +210,17 @@ export default function CreateExam() {
     [saving, loadingCourses, loadingExam]
   );
 
+  const totalPuntos = useMemo(() => sumPreguntasPuntos(questions), [questions]);
+  const puntosValidos = totalPuntos === PUNTOS_TOTAL_EXAMEN;
+
   const updateQuestion = (questionId: string, updater: (q: QuestionForm) => QuestionForm) => {
     setQuestions((prev) => prev.map((q) => (q.id === questionId ? updater(q) : q)));
   };
 
   const addQuestion = () => {
     scrollToNewQuestion.current = true;
-    setQuestions((prev) => [...prev, createEmptyQuestion()]);
+    setQuestions((prev) => applyEqualPuntos([...prev, createEmptyQuestion()]));
+    setPuntosError("");
   };
 
   useEffect(() => {
@@ -201,12 +230,26 @@ export default function CreateExam() {
   }, [questions.length]);
 
   const removeQuestion = (questionId: string) => {
-    setQuestions((prev) => prev.filter((q) => q.id !== questionId));
+    setQuestions((prev) => applyEqualPuntos(prev.filter((q) => q.id !== questionId)));
+    setPuntosError("");
     setQuestionErrors((prev) => {
       const next = { ...prev };
       delete next[questionId];
       return next;
     });
+  };
+
+  const redistributePuntos = () => {
+    setQuestions((prev) => applyEqualPuntos(prev));
+    setPuntosError("");
+  };
+
+  const updateQuestionPuntos = (questionId: string, value: string) => {
+    const parsed = Number.parseInt(value, 10);
+    const puntos = Number.isNaN(parsed) ? 0 : Math.max(0, parsed);
+    updateQuestion(questionId, (q) => ({ ...q, puntos }));
+    setPuntosError("");
+    clearQuestionError(questionId, "puntos");
   };
 
   const addOption = (questionId: string) => {
@@ -248,7 +291,7 @@ export default function CreateExam() {
 
       const updated = { ...current };
       delete updated[field];
-      if (!updated.texto && !updated.respuestas) {
+      if (!updated.texto && !updated.respuestas && !updated.puntos) {
         const next = { ...prev };
         delete next[questionId];
         return next;
@@ -265,6 +308,7 @@ export default function CreateExam() {
     setTitleError("");
     setFormationError("");
     setQuestionsError("");
+    setPuntosError("");
 
     const markInvalid = (fieldId: string) => {
       isValid = false;
@@ -307,10 +351,17 @@ export default function CreateExam() {
         markInvalid(`question-${question.id}`);
       }
 
-      if (qError.texto || qError.respuestas) {
+      if (qError.texto || qError.respuestas || qError.puntos) {
         nextQuestionErrors[question.id] = qError;
       }
     });
+
+    if (totalPuntos !== PUNTOS_TOTAL_EXAMEN) {
+      setPuntosError(
+        `La suma de puntos debe ser ${PUNTOS_TOTAL_EXAMEN} (actual: ${totalPuntos})`
+      );
+      markInvalid("puntos-total");
+    }
 
     setQuestionErrors(nextQuestionErrors);
     return { isValid, firstErrorField };
@@ -333,6 +384,7 @@ export default function CreateExam() {
       preguntas: questions.map((q) => ({
         id: q.id,
         texto: q.texto.trim(),
+        puntos: q.puntos,
         respuestas: q.respuestas.map((r) => ({
             id: r.id,
             texto: r.texto.trim(),
@@ -443,10 +495,28 @@ export default function CreateExam() {
             <div className="space-y-4" ref={setFieldRef("questions")}>
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <Label className="text-base">Preguntas</Label>
-                {questionsError && (
-                  <p className="text-sm text-red-600">{questionsError}</p>
-                )}
+                <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+                  <div ref={setFieldRef("puntos-total")}>
+                    <Badge variant={puntosValidos ? "default" : "destructive"}>
+                      Total puntos: {totalPuntos} / {PUNTOS_TOTAL_EXAMEN}
+                    </Badge>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={redistributePuntos}
+                  >
+                    Distribuir equitativamente
+                  </Button>
+                </div>
               </div>
+              {questionsError && (
+                <p className="text-sm text-red-600">{questionsError}</p>
+              )}
+              {puntosError && (
+                <p className="text-sm text-red-600">{puntosError}</p>
+              )}
 
               {questions.map((question, index) => (
                 <Card
@@ -456,16 +526,34 @@ export default function CreateExam() {
                   <CardHeader className="pb-2">
                     <div className="flex items-center justify-between gap-2">
                       <CardTitle className="text-base">Pregunta {index + 1}</CardTitle>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => removeQuestion(question.id)}
-                        disabled={questions.length === 1}
-                      >
-                        <Trash2 className="w-4 h-4 mr-1" />
-                        Eliminar
-                      </Button>
+                      <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2">
+                          <Label htmlFor={`puntos-${question.id}`} className="text-sm whitespace-nowrap">
+                            Puntos
+                          </Label>
+                          <Input
+                            id={`puntos-${question.id}`}
+                            type="number"
+                            min={1}
+                            max={100}
+                            className="w-20 h-8"
+                            value={question.puntos}
+                            onChange={(e) =>
+                              updateQuestionPuntos(question.id, e.target.value)
+                            }
+                          />
+                        </div>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => removeQuestion(question.id)}
+                          disabled={questions.length === 1}
+                        >
+                          <Trash2 className="w-4 h-4 mr-1" />
+                          Eliminar
+                        </Button>
+                      </div>
                     </div>
                   </CardHeader>
                   <CardContent className="space-y-4">

--- a/src/service/completedExams.ts
+++ b/src/service/completedExams.ts
@@ -133,6 +133,17 @@ export const CompletedExamsAPI = {
             return {
               id: String(pr.id ?? pr.idPregunta ?? ""),
               texto: String(pr.texto ?? pr.pregunta ?? ""),
+              puntos: typeof pr.puntos === "number" ? pr.puntos : undefined,
+              puntosObtenidos:
+                typeof pr.puntosObtenidos === "number"
+                  ? pr.puntosObtenidos
+                  : undefined,
+              acertada:
+                typeof pr.acertada === "boolean"
+                  ? pr.acertada
+                  : typeof pr.esCorrecta === "boolean"
+                    ? pr.esCorrecta
+                    : undefined,
               respuestas: Array.isArray(respuestasRaw)
                 ? respuestasRaw.map((r) => {
                     const rr = r as Record<string, unknown>;
@@ -149,7 +160,21 @@ export const CompletedExamsAPI = {
             };
           })
         : undefined;
-      return { ...base, preguntas, _raw: raw };
+      return {
+        ...base,
+        preguntas,
+        intentoNumero:
+          raw.intentoNumero != null ? Number(raw.intentoNumero) : undefined,
+        totalIntentos:
+          raw.totalIntentos != null ? Number(raw.totalIntentos) : undefined,
+        porcentajeAciertos:
+          raw.porcentajeAciertos != null
+            ? Number(raw.porcentajeAciertos)
+            : undefined,
+        puntosObtenidos:
+          raw.puntosObtenidos != null ? Number(raw.puntosObtenidos) : undefined,
+        _raw: raw,
+      };
     } catch (error: unknown) {
       throw new Error(
         getAxiosErrorMessage(error, "Error al obtener detalle del examen realizado")

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -259,6 +259,7 @@ export interface ExamenRespuesta {
 export interface ExamenPregunta {
   id: string;
   texto: string;
+  puntos?: number;
   respuestas: ExamenRespuesta[];
 }
 
@@ -293,6 +294,9 @@ export interface ExamenRealizado {
 export interface ExamenRealizadoPreguntaDetalle {
   id: string;
   texto: string;
+  puntos?: number;
+  puntosObtenidos?: number;
+  acertada?: boolean;
   respuestas: ExamenRespuesta[];
   respuestasSeleccionadas?: string[];
   idsRespuestasSeleccionadas?: string[];
@@ -300,4 +304,8 @@ export interface ExamenRealizadoPreguntaDetalle {
 
 export interface ExamenRealizadoDetalle extends ExamenRealizado {
   preguntas?: ExamenRealizadoPreguntaDetalle[];
+  intentoNumero?: number;
+  totalIntentos?: number;
+  porcentajeAciertos?: number;
+  puntosObtenidos?: number;
 }

--- a/src/utils/completedExamDetail.ts
+++ b/src/utils/completedExamDetail.ts
@@ -3,6 +3,38 @@ import type {
   ExamenRealizadoDetalle,
   ExamenRealizadoPreguntaDetalle,
 } from "@/types/types";
+import { distributePuntosEqually } from "@/utils/examPoints";
+
+function isQuestionCorrectLocally(
+  respuestas: Array<{ id: string; esCorrecta: boolean }>,
+  selectedIds: string[]
+): boolean {
+  const correctIds = respuestas
+    .filter((r) => r.esCorrecta)
+    .map((r) => r.id)
+    .sort();
+  const selected = [...selectedIds].sort();
+  if (correctIds.length !== selected.length) return false;
+  return correctIds.every((id, index) => id === selected[index]);
+}
+
+function resolveQuestionScore(
+  pregunta: ExamenRealizadoPreguntaDetalle,
+  selectedIds: string[]
+): Pick<ExamenRealizadoPreguntaDetalle, "acertada" | "puntosObtenidos"> {
+  const acertada =
+    typeof pregunta.acertada === "boolean"
+      ? pregunta.acertada
+      : isQuestionCorrectLocally(pregunta.respuestas, selectedIds);
+  const puntosObtenidos =
+    typeof pregunta.puntosObtenidos === "number"
+      ? pregunta.puntosObtenidos
+      : acertada && typeof pregunta.puntos === "number"
+        ? pregunta.puntos
+        : 0;
+
+  return { acertada, puntosObtenidos };
+}
 
 function toAnswerId(value: unknown): string {
   if (value == null) return "";
@@ -145,6 +177,15 @@ function normalizeQuestionFromRaw(
   return {
     id: qId,
     texto: String(pr.texto ?? pr.pregunta ?? ""),
+    puntos: typeof pr.puntos === "number" ? pr.puntos : undefined,
+    puntosObtenidos:
+      typeof pr.puntosObtenidos === "number" ? pr.puntosObtenidos : undefined,
+    acertada:
+      typeof pr.acertada === "boolean"
+        ? pr.acertada
+        : typeof pr.esCorrecta === "boolean"
+          ? pr.esCorrecta
+          : undefined,
     respuestas,
     respuestasSeleccionadas,
   };
@@ -161,17 +202,28 @@ export function buildCompletedExamQuestions(
   const selections = extractStudentSelections(raw);
 
   if (examTemplate?.preguntas?.length) {
-    return examTemplate.preguntas.map((q) => {
+    const puntosDistribution = distributePuntosEqually(examTemplate.preguntas.length);
+
+    return examTemplate.preguntas.map((q, index) => {
       const selected = Array.from(selections.get(q.id) ?? []);
       const fromQuestion = record.preguntas?.find((p) => p.id === q.id);
       const mergedSelected =
         fromQuestion?.respuestasSeleccionadas?.length
           ? fromQuestion.respuestasSeleccionadas
           : selected;
+      const puntos =
+        typeof q.puntos === "number"
+          ? q.puntos
+          : typeof fromQuestion?.puntos === "number"
+            ? fromQuestion.puntos
+            : puntosDistribution[index];
 
-      return {
+      const baseQuestion: ExamenRealizadoPreguntaDetalle = {
         id: q.id,
         texto: q.texto,
+        puntos,
+        puntosObtenidos: fromQuestion?.puntosObtenidos,
+        acertada: fromQuestion?.acertada,
         respuestas: q.respuestas.map((r) => ({
           id: r.id,
           texto: r.texto,
@@ -179,6 +231,9 @@ export function buildCompletedExamQuestions(
         })),
         respuestasSeleccionadas: mergedSelected,
       };
+
+      const score = resolveQuestionScore(baseQuestion, mergedSelected);
+      return { ...baseQuestion, ...score };
     });
   }
 

--- a/src/utils/examPoints.ts
+++ b/src/utils/examPoints.ts
@@ -1,0 +1,35 @@
+export const PUNTOS_TOTAL_EXAMEN = 100;
+
+/** Reparte 100 puntos en partes enteras lo más equitativas posible. */
+export const distributePuntosEqually = (count: number): number[] => {
+  if (count <= 0) return [];
+  const base = Math.floor(PUNTOS_TOTAL_EXAMEN / count);
+  const remainder = PUNTOS_TOTAL_EXAMEN - base * count;
+  return Array.from({ length: count }, (_, index) =>
+    base + (index < remainder ? 1 : 0)
+  );
+};
+
+export const sumPreguntasPuntos = (
+  preguntas: Array<{ puntos?: number }>
+): number =>
+  preguntas.reduce((acc, pregunta) => acc + (pregunta.puntos ?? 0), 0);
+
+export const sumPreguntasPuntosObtenidos = (
+  preguntas: Array<{ puntosObtenidos?: number; acertada?: boolean; puntos?: number }>
+): number =>
+  preguntas.reduce((acc, pregunta) => {
+    if (typeof pregunta.puntosObtenidos === "number") {
+      return acc + pregunta.puntosObtenidos;
+    }
+    if (pregunta.acertada && typeof pregunta.puntos === "number") {
+      return acc + pregunta.puntos;
+    }
+    return acc;
+  }, 0);
+
+export const computePorcentajeFromPuntos = (puntosObtenidos: number): number =>
+  Math.round(((puntosObtenidos / PUNTOS_TOTAL_EXAMEN) * 100) * 10) / 10;
+
+export const computeNotaFromPorcentaje = (porcentaje: number): number =>
+  Math.round((porcentaje / 10) * 10) / 10;


### PR DESCRIPTION
Ticket:  EPEFI-137

## Qué y por qué

Se agregó la UI para asignar y editar puntos por pregunta en crear/editar examen, con validación de suma = 100, distribución automática al agregar/quitar preguntas, y visualización de puntos por pregunta, puntos obtenidos totales, porcentaje recalculado e intentos en el detalle del examen realizado.

El admin recalcula en cliente como respaldo, pero la fuente de verdad es el backend.

## Qué puede romper
Guardar examen con suma ≠ 100: bloqueado en UI y rechazado por API.
Exámenes viejos sin puntos: al editar, se redistribuyen equitativamente al cargar.

![Uploading image.png…]()


