### PR TITLE
[FEAT]EPEFI-138:Se agrega funcionalidad de contador de tiempo para ex…

### DIFF
--- a/src/components/product/SubjectCreation.tsx
+++ b/src/components/product/SubjectCreation.tsx
@@ -281,8 +281,7 @@ export default function SubjectCreation({ courseId, control, courseTitle }: Subj
             
             return response;
         } catch (err: unknown) {
-            const errorMessage = err instanceof Error ? err.message : 'Error desconocido';
-            toast.error("Error al crear materia: " + errorMessage);
+            // SubjectModal muestra el mensaje del backend (p. ej. nombre duplicado)
             throw err;
         }
     };
@@ -459,7 +458,7 @@ export default function SubjectCreation({ courseId, control, courseTitle }: Subj
             handleCancelEditSubject();
         } catch (err) {
             console.error(err);
-            toast.error("Error al actualizar la materia");
+            // SubjectModal muestra el mensaje del backend
             throw err;
         }
     };

--- a/src/components/subject/SubjectModal.tsx
+++ b/src/components/subject/SubjectModal.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Loader2, BookOpen, Settings, Trash2 } from 'lucide-react';
 import { safeSetItem } from '@/utils/storage';
 import { toast } from 'sonner';
+import { extractErrorMessage } from '@/utils/errorMessages';
 
 import {
     Dialog,
@@ -298,7 +299,7 @@ const SubjectModal = ({
             }
         } catch (error) {
             console.error('Error al procesar materia:', error);
-            toast.error('Error al guardar la materia. Por favor, inténtalo de nuevo.');
+            toast.error(extractErrorMessage(error) || 'Error al guardar la materia. Por favor, inténtalo de nuevo.');
         } finally {
             setLoading(false);
         }
@@ -531,7 +532,7 @@ const SubjectModal = ({
                                         }
                                     } catch (error) {
                                         console.error('Error al guardar materia:', error);
-                                        toast.error('Error al guardar la materia. Por favor, inténtalo de nuevo.');
+                                        toast.error(extractErrorMessage(error) || 'Error al guardar la materia. Por favor, inténtalo de nuevo.');
                                     } finally {
                                         setLoading(false);
                                     }
@@ -564,7 +565,7 @@ const SubjectModal = ({
                                         }
                                     } catch (error) {
                                         console.error('Error al guardar materia:', error);
-                                        alert('Error al guardar la materia. Por favor, inténtalo de nuevo.');
+                                        toast.error(extractErrorMessage(error) || 'Error al guardar la materia. Por favor, inténtalo de nuevo.');
                                     } finally {
                                         setLoading(false);
                                     }

--- a/src/pages/CreateExam.tsx
+++ b/src/pages/CreateExam.tsx
@@ -63,11 +63,18 @@ const createEmptyQuestion = (): QuestionForm => ({
 function examToFormState(exam: Examen): {
   title: string;
   idFormacion: string;
+  duracionMinutos: number;
   questions: QuestionForm[];
 } {
+  const duracion =
+    typeof exam.duracionMinutos === "number" && exam.duracionMinutos > 0
+      ? exam.duracionMinutos
+      : 90;
+
   return {
     title: exam.titulo || "",
     idFormacion: exam.idFormacion || "",
+    duracionMinutos: duracion,
     questions:
       exam.preguntas?.length > 0
         ? exam.preguntas.map((q) => ({
@@ -93,6 +100,8 @@ export default function CreateExam() {
   const { sidebarWidth } = useSidebarLayout();
   const [title, setTitle] = useState("");
   const [idFormacion, setIdFormacion] = useState("");
+  const [duracionMinutos, setDuracionMinutos] = useState(90);
+  const [duracionError, setDuracionError] = useState("");
   const [questions, setQuestions] = useState<QuestionForm[]>([createEmptyQuestion()]);
   const [courses, setCourses] = useState<Course[]>([]);
   const [loadingCourses, setLoadingCourses] = useState(true);
@@ -165,6 +174,7 @@ export default function CreateExam() {
         const form = examToFormState(exam);
         setTitle(form.title);
         setIdFormacion(form.idFormacion);
+        setDuracionMinutos(form.duracionMinutos);
         setQuestions(form.questions);
       } catch (error) {
         console.error("Error al cargar examen:", error);
@@ -264,6 +274,7 @@ export default function CreateExam() {
     const nextQuestionErrors: Record<string, QuestionError> = {};
     setTitleError("");
     setFormationError("");
+    setDuracionError("");
     setQuestionsError("");
 
     const markInvalid = (fieldId: string) => {
@@ -279,6 +290,16 @@ export default function CreateExam() {
     if (!idFormacion) {
       setFormationError("Debes seleccionar una formación");
       markInvalid("formation");
+    }
+
+    if (
+      !Number.isFinite(duracionMinutos) ||
+      !Number.isInteger(duracionMinutos) ||
+      duracionMinutos < 1 ||
+      duracionMinutos > 480
+    ) {
+      setDuracionError("La duración debe ser un número entero entre 1 y 480 minutos");
+      markInvalid("duration");
     }
 
     if (questions.length === 0) {
@@ -330,6 +351,7 @@ export default function CreateExam() {
     const payload: ExamenCreatePayload = {
       titulo: title.trim(),
       idFormacion,
+      duracionMinutos,
       preguntas: questions.map((q) => ({
         id: q.id,
         texto: q.texto.trim(),
@@ -438,6 +460,27 @@ export default function CreateExam() {
                 </SelectContent>
               </Select>
               {formationError && <p className="text-sm text-red-600">{formationError}</p>}
+            </div>
+
+            <div className="space-y-2" ref={setFieldRef("duration")}>
+              <Label htmlFor="exam-duration">Duración del examen (minutos)</Label>
+              <Input
+                id="exam-duration"
+                type="number"
+                min={1}
+                max={480}
+                step={1}
+                value={duracionMinutos}
+                onChange={(e) => {
+                  const value = Number(e.target.value);
+                  setDuracionMinutos(Number.isNaN(value) ? 0 : value);
+                  if (duracionError) setDuracionError("");
+                }}
+              />
+              <p className="text-xs text-muted-foreground">
+                Valor base: 90 minutos. Podés modificarlo según la evaluación.
+              </p>
+              {duracionError && <p className="text-sm text-red-600">{duracionError}</p>}
             </div>
 
             <div className="space-y-4" ref={setFieldRef("questions")}>

--- a/src/pages/Subjects.tsx
+++ b/src/pages/Subjects.tsx
@@ -139,11 +139,9 @@ export default function Subjects() {
 
             setMaterias(prev => [newSubject, ...prev]);
 
-            // No mostrar toast aquí porque se mostrará en SubjectModal después de guardar
+            // No mostrar toast aquí: SubjectModal muestra el mensaje del backend
             return newSubject;
         } catch (err: unknown) {
-            const errorMessage = err instanceof Error ? err.message : 'Error desconocido';
-            toast.error("Error al crear materia: " + errorMessage);
             throw err;
         }
     };
@@ -175,8 +173,6 @@ export default function Subjects() {
             ));
             toast.success("Materia actualizada exitosamente");
         } catch (err: unknown) {
-            const errorMessage = err instanceof Error ? err.message : 'Error desconocido';
-            toast.error("Error al actualizar materia: " + errorMessage);
             throw err;
         }
     };

--- a/src/service/courses.ts
+++ b/src/service/courses.ts
@@ -3,6 +3,7 @@ import { auth } from "@/firebase";
 import axios from "axios";
 import { type Course, type Subject, type Module } from "@/types/types";
 import { normalizePaginatedResponse } from "@/utils/pagination";
+import { extractAxiosResponseDataMessage } from "@/utils/errorMessages";
 import { storage } from "../../config/firebase-client";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 
@@ -298,11 +299,11 @@ export const CoursesAPI = {
       return res.data;
     } catch (error: unknown) {
       const axiosError = error as {
-        response?: { data?: { error?: string } };
+        response?: { data?: unknown };
         message?: string;
       };
       const errorMessage =
-        axiosError.response?.data?.error ||
+        extractAxiosResponseDataMessage(axiosError.response?.data) ||
         axiosError.message ||
         "Error al crear materia";
       throw new Error(errorMessage);
@@ -315,11 +316,11 @@ export const CoursesAPI = {
       return res.data;
     } catch (error: unknown) {
       const axiosError = error as {
-        response?: { data?: { message?: string } };
+        response?: { data?: unknown };
         message?: string;
       };
       const errorMessage =
-        axiosError.response?.data?.message ||
+        extractAxiosResponseDataMessage(axiosError.response?.data) ||
         axiosError.message ||
         "Error al actualizar materia";
       throw new Error(errorMessage);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -265,6 +265,8 @@ export interface ExamenPregunta {
 export interface ExamenCreatePayload {
   titulo: string;
   idFormacion: string;
+  /** Duración del examen en minutos. Por defecto 90. */
+  duracionMinutos: number;
   preguntas: ExamenPregunta[];
 }
 


### PR DESCRIPTION
…amen

Ticket: EPEFI-138

## Qué y por qué

Agregamos duración configurable del examen (base 90 min) y un contador visible en el alumno: al llegar a 0 o al cerrar a mitad, se registra el intento. el tiempo y el abandono quedan guardados en examenes_realizados con motivoCierre (envio / tiempo / abandono). En el admin se edita duracionMinutos y se persiste en la colección examenes.

## Qué puede romper

Al cerrar a mitad se cuenta intento (regla explícita de aceptación); conviene confirmar que no haya casos (ej. error de red / pestaña) donde eso genere intentos “fantasma” no deseados.

## Capturas
Admin:
<img width="1560" height="1042" alt="image" src="https://github.com/user-attachments/assets/9b3f7aa7-5c69-4f2e-be20-b1ab6bc6074b" />

<!-- Capturas de la UI si es el cambio fue en el frontend. Si es backend: el response, el log o la query con su resultado. -->
