### PR TITLE
[FIX]EPEFI-139:Se agrega consistencia en detalle de examen luego de e…

### DIFF
--- a/src/pages/CompletedExamDetail.tsx
+++ b/src/pages/CompletedExamDetail.tsx
@@ -54,6 +54,7 @@ export default function CompletedExamDetail() {
   const [preguntas, setPreguntas] = useState<ExamenRealizadoPreguntaDetalle[]>([]);
   const [formationTitle, setFormationTitle] = useState("");
   const [examTitle, setExamTitle] = useState("");
+  const [detalleIncompleto, setDetalleIncompleto] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -67,13 +68,20 @@ export default function CompletedExamDetail() {
         const data = await CompletedExamsAPI.getById(id);
         const raw = data._raw;
 
+        // Solo para título / fallback legacy. El detalle prioriza el snapshot del intento.
         const exam = data.idExamen
           ? await ExamsAPI.getById(data.idExamen).catch(() => null)
           : null;
 
         const merged = buildCompletedExamQuestions(data, raw, exam);
         setPreguntas(merged);
+        setDetalleIncompleto(
+          raw.detalleIncompleto === true ||
+            (merged.length > 0 &&
+              merged.every((q) => (q.respuestas?.length ?? 0) === 0))
+        );
 
+        // Nota y puntaje del intento guardado; no recalcular contra el examen editado.
         const puntosFromQuestions = sumPreguntasPuntosObtenidos(merged);
         const puntosObtenidos =
           typeof data.puntosObtenidos === "number"
@@ -87,7 +95,10 @@ export default function CompletedExamDetail() {
           typeof data.nota === "number"
             ? data.nota
             : computeNotaFromPorcentaje(porcentajeAciertos);
-        const aprobado = porcentajeAciertos >= 70;
+        const aprobado =
+          typeof data.aprobado === "boolean"
+            ? data.aprobado
+            : porcentajeAciertos >= 70;
 
         setMeta({
           id: data.id,
@@ -227,10 +238,19 @@ export default function CompletedExamDetail() {
         <h2 className="text-lg font-semibold text-gray-900">
           Preguntas y respuestas
         </h2>
+        {detalleIncompleto && (
+          <p className="text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+            Este intento se rindió antes de que el sistema guardara una copia de
+            las preguntas, y el examen se editó después. La nota del encabezado
+            es la correcta; el detalle de cada pregunta ya no se puede
+            reconstruir. Los intentos nuevos sí conservan el detalle aunque se
+            edite el examen.
+          </p>
+        )}
         {preguntas.length === 0 ? (
           <p className="text-muted-foreground text-sm">
             No se pudo reconstruir el detalle de preguntas. Verifica que el
-            registro incluya respuestas o que el examen original siga existiendo.
+            registro del intento incluya el snapshot de preguntas y respuestas.
           </p>
         ) : (
           preguntas.map((q, index) => {

--- a/src/service/completedExams.ts
+++ b/src/service/completedExams.ts
@@ -155,7 +155,15 @@ export const CompletedExamsAPI = {
                       ),
                     };
                   })
-                : [],
+                : Array.isArray(pr.opciones)
+                  ? (pr.opciones as Record<string, unknown>[]).map((rr) => ({
+                      id: String(rr.id ?? ""),
+                      texto: String(rr.texto ?? rr.text ?? ""),
+                      esCorrecta: Boolean(
+                        rr.esCorrecta ?? rr.correcta ?? rr.isCorrect
+                      ),
+                    }))
+                  : [],
               respuestasSeleccionadas: seleccionadas,
             };
           })

--- a/src/utils/completedExamDetail.ts
+++ b/src/utils/completedExamDetail.ts
@@ -191,34 +191,119 @@ function normalizeQuestionFromRaw(
   };
 }
 
+function withResolvedScore(
+  question: ExamenRealizadoPreguntaDetalle,
+  selections: Map<string, Set<string>>
+): ExamenRealizadoPreguntaDetalle {
+  const selected =
+    question.respuestasSeleccionadas?.length
+      ? question.respuestasSeleccionadas
+      : Array.from(selections.get(question.id) ?? []);
+  const withSelected = { ...question, respuestasSeleccionadas: selected };
+  const score = resolveQuestionScore(withSelected, selected);
+  return { ...withSelected, ...score };
+}
+
 /**
- * Arma el detalle mostrable: plantilla del examen + respuestas del alumno.
+ * Preguntas del intento (snapshot). Prioriza el registro ya normalizado y,
+ * si hace falta, el payload crudo del backend.
  */
-export function buildCompletedExamQuestions(
+function buildQuestionsFromAttemptSnapshot(
   record: ExamenRealizadoDetalle,
   raw: Record<string, unknown>,
-  examTemplate: Examen | null | undefined
+  selections: Map<string, Set<string>>
 ): ExamenRealizadoPreguntaDetalle[] {
-  const selections = extractStudentSelections(raw);
+  const fromRecord = record.preguntas ?? [];
+  if (fromRecord.length > 0) {
+    const built = fromRecord
+      .map((p) =>
+        normalizeQuestionFromRaw(
+          p as unknown as Record<string, unknown>,
+          selections
+        )
+      )
+      .filter((q): q is ExamenRealizadoPreguntaDetalle => q != null);
+    if (built.length > 0) return built;
+  }
 
-  if (examTemplate?.preguntas?.length) {
-    const puntosDistribution = distributePuntosEqually(examTemplate.preguntas.length);
+  const preguntasRaw = raw.preguntas;
+  if (!Array.isArray(preguntasRaw) || preguntasRaw.length === 0) return [];
 
-    return examTemplate.preguntas.map((q, index) => {
-      const selected = Array.from(selections.get(q.id) ?? []);
-      const fromQuestion = record.preguntas?.find((p) => p.id === q.id);
-      const mergedSelected =
-        fromQuestion?.respuestasSeleccionadas?.length
-          ? fromQuestion.respuestasSeleccionadas
-          : selected;
-      const puntos =
-        typeof q.puntos === "number"
+  return preguntasRaw
+    .map((p) =>
+      normalizeQuestionFromRaw(p as Record<string, unknown>, selections)
+    )
+    .filter((q): q is ExamenRealizadoPreguntaDetalle => q != null);
+}
+
+/**
+ * Completa texto/opciones faltantes desde la plantilla actual, pero solo para
+ * IDs que ya estaban en el intento (no agrega preguntas nuevas del examen editado).
+ */
+function enrichSnapshotFromTemplate(
+  snapshot: ExamenRealizadoPreguntaDetalle[],
+  examTemplate: Examen,
+  selections: Map<string, Set<string>>
+): ExamenRealizadoPreguntaDetalle[] {
+  const templateById = new Map(
+    examTemplate.preguntas.map((q) => [q.id, q] as const)
+  );
+
+  return snapshot.map((q) => {
+    const template = templateById.get(q.id);
+    if (!template) return withResolvedScore(q, selections);
+
+    const respuestas =
+      q.respuestas.length > 0
+        ? q.respuestas
+        : template.respuestas.map((r) => ({
+            id: r.id,
+            texto: r.texto,
+            esCorrecta: Boolean(r.esCorrecta),
+          }));
+
+    return withResolvedScore(
+      {
+        ...q,
+        texto: q.texto || template.texto,
+        puntos:
+          typeof q.puntos === "number"
+            ? q.puntos
+            : typeof template.puntos === "number"
+              ? template.puntos
+              : q.puntos,
+        respuestas,
+      },
+      selections
+    );
+  });
+}
+
+function buildQuestionsFromLiveTemplate(
+  record: ExamenRealizadoDetalle,
+  examTemplate: Examen,
+  selections: Map<string, Set<string>>
+): ExamenRealizadoPreguntaDetalle[] {
+  const puntosDistribution = distributePuntosEqually(
+    examTemplate.preguntas.length
+  );
+
+  return examTemplate.preguntas.map((q, index) => {
+    const selected = Array.from(selections.get(q.id) ?? []);
+    const fromQuestion = record.preguntas?.find((p) => p.id === q.id);
+    const mergedSelected =
+      fromQuestion?.respuestasSeleccionadas?.length
+        ? fromQuestion.respuestasSeleccionadas
+        : selected;
+    const puntos =
+      typeof fromQuestion?.puntos === "number"
+        ? fromQuestion.puntos
+        : typeof q.puntos === "number"
           ? q.puntos
-          : typeof fromQuestion?.puntos === "number"
-            ? fromQuestion.puntos
-            : puntosDistribution[index];
+          : puntosDistribution[index];
 
-      const baseQuestion: ExamenRealizadoPreguntaDetalle = {
+    return withResolvedScore(
+      {
         id: q.id,
         texto: q.texto,
         puntos,
@@ -230,39 +315,52 @@ export function buildCompletedExamQuestions(
           esCorrecta: Boolean(r.esCorrecta),
         })),
         respuestasSeleccionadas: mergedSelected,
-      };
+      },
+      selections
+    );
+  });
+}
 
-      const score = resolveQuestionScore(baseQuestion, mergedSelected);
-      return { ...baseQuestion, ...score };
+/**
+ * Arma el detalle mostrable priorizando el snapshot del intento.
+ * La plantilla actual del examen solo se usa como respaldo legacy o para
+ * completar opciones faltantes de preguntas que ya existían al rendir.
+ */
+export function buildCompletedExamQuestions(
+  record: ExamenRealizadoDetalle,
+  raw: Record<string, unknown>,
+  examTemplate: Examen | null | undefined
+): ExamenRealizadoPreguntaDetalle[] {
+  const selections = extractStudentSelections(raw);
+  const snapshot = buildQuestionsFromAttemptSnapshot(record, raw, selections);
+
+  if (snapshot.length > 0) {
+    const hasOptions = snapshot.some((q) => q.respuestas.length > 0);
+    if (hasOptions) {
+      return snapshot.map((q) => withResolvedScore(q, selections));
+    }
+    if (examTemplate?.preguntas?.length) {
+      return enrichSnapshotFromTemplate(snapshot, examTemplate, selections);
+    }
+    // Sin opciones en plantilla: respetar puntaje/acertada ya guardados en el intento
+    return snapshot.map((q) => {
+      const selected =
+        q.respuestasSeleccionadas?.length
+          ? q.respuestasSeleccionadas
+          : Array.from(selections.get(q.id) ?? []);
+      if (
+        typeof q.acertada === "boolean" ||
+        typeof q.puntosObtenidos === "number"
+      ) {
+        return { ...q, respuestasSeleccionadas: selected };
+      }
+      return withResolvedScore({ ...q, respuestasSeleccionadas: selected }, selections);
     });
   }
 
-  const fromRecord = record.preguntas ?? [];
-  if (fromRecord.length > 0) {
-    const built = fromRecord
-      .map((p) =>
-        normalizeQuestionFromRaw(p as unknown as Record<string, unknown>, selections)
-      )
-      .filter((q): q is ExamenRealizadoPreguntaDetalle => q != null);
-
-    if (built.some((q) => q.respuestas.length > 0)) {
-      return built.map((q) => ({
-        ...q,
-        respuestasSeleccionadas:
-          q.respuestasSeleccionadas?.length
-            ? q.respuestasSeleccionadas
-            : Array.from(selections.get(q.id) ?? []),
-      }));
-    }
-  }
-
-  const preguntasRaw = raw.preguntas;
-  if (Array.isArray(preguntasRaw)) {
-    return preguntasRaw
-      .map((p) =>
-        normalizeQuestionFromRaw(p as Record<string, unknown>, selections)
-      )
-      .filter((q): q is ExamenRealizadoPreguntaDetalle => q != null);
+  // Legacy: intentos sin snapshot de preguntas → reconstruir con plantilla actual
+  if (examTemplate?.preguntas?.length) {
+    return buildQuestionsFromLiveTemplate(record, examTemplate, selections);
   }
 
   return [];


### PR DESCRIPTION
…ditarlo

Ticket: EPEFI-139

## Qué y por qué
El detalle de un examen rendido se armaba con la plantilla actual, entonces editar preguntas cambiaba el historial. Ahora cada intento guarda un snapshot al rendir (y al editar se congela lo pendiente), y el detalle usa esa copia + la nota guardada.

## Qué puede romper

Intentos viejos sin snapshot, si el examen ya se editó, pueden no mostrar el texto de las preguntas (la nota del encabezado sigue siendo la correcta). 

## Capturas
<img width="1918" height="1070" alt="Screenshot 2026-08-19 141619" src="https://github.com/user-attachments/assets/0a73bb6e-e6e7-417f-a7d9-63234060f58b" />
<img width="1562" height="1051" alt="Screenshot 2026-08-19 141835" src="https://github.com/user-attachments/assets/ab32538b-657d-4b40-96c5-8488cb095d23" />
<img width="1912" height="992" alt="Screenshot 2026-08-19 141931" src="https://github.com/user-attachments/assets/f970895d-46f6-46fd-a664-3e00935ab780" />

<!-- Capturas de la UI si es el cambio fue en el frontend. Si es backend: el response, el log o la query con su resultado. -->
