### PR TITLE
[FIX]EPEFI-140:Se arregla distribucion equitativa con decimales

### DIFF
--- a/src/pages/CreateExam.tsx
+++ b/src/pages/CreateExam.tsx
@@ -22,7 +22,10 @@ import { toast } from "sonner";
 import { useSidebarLayout } from "@/context/SidebarLayoutContext";
 import {
   distributePuntosEqually,
+  parsePuntosInput,
+  puntosSumEqualsTotal,
   PUNTOS_TOTAL_EXAMEN,
+  roundPuntos,
   sumPreguntasPuntos,
 } from "@/utils/examPoints";
 
@@ -137,6 +140,7 @@ export default function CreateExam() {
   const [questionsError, setQuestionsError] = useState("");
   const [questionErrors, setQuestionErrors] = useState<Record<string, QuestionError>>({});
   const [puntosError, setPuntosError] = useState("");
+  const [puntosDraft, setPuntosDraft] = useState<Record<string, string>>({});
   const lastQuestionRef = useRef<HTMLDivElement | null>(null);
   const scrollToNewQuestion = useRef(false);
   const fieldRefs = useRef<Record<string, HTMLElement | null>>({});
@@ -221,7 +225,7 @@ export default function CreateExam() {
   );
 
   const totalPuntos = useMemo(() => sumPreguntasPuntos(questions), [questions]);
-  const puntosValidos = totalPuntos === PUNTOS_TOTAL_EXAMEN;
+  const puntosValidos = puntosSumEqualsTotal(totalPuntos);
 
   const updateQuestion = (questionId: string, updater: (q: QuestionForm) => QuestionForm) => {
     setQuestions((prev) => prev.map((q) => (q.id === questionId ? updater(q) : q)));
@@ -242,6 +246,11 @@ export default function CreateExam() {
   const removeQuestion = (questionId: string) => {
     setQuestions((prev) => applyEqualPuntos(prev.filter((q) => q.id !== questionId)));
     setPuntosError("");
+    setPuntosDraft((prev) => {
+      const next = { ...prev };
+      delete next[questionId];
+      return next;
+    });
     setQuestionErrors((prev) => {
       const next = { ...prev };
       delete next[questionId];
@@ -251,15 +260,44 @@ export default function CreateExam() {
 
   const redistributePuntos = () => {
     setQuestions((prev) => applyEqualPuntos(prev));
+    setPuntosDraft({});
     setPuntosError("");
   };
 
   const updateQuestionPuntos = (questionId: string, value: string) => {
-    const parsed = Number.parseInt(value, 10);
-    const puntos = Number.isNaN(parsed) ? 0 : Math.max(0, parsed);
-    updateQuestion(questionId, (q) => ({ ...q, puntos }));
+    const normalized = value.replace(",", ".");
+    // Permitir teclear decimales a medias (ej. "33." / "33,")
+    if (normalized !== "" && !/^\d*\.?\d*$/.test(normalized)) {
+      return;
+    }
+
+    setPuntosDraft((prev) => ({ ...prev, [questionId]: value }));
+
+    if (normalized === "" || normalized === ".") {
+      updateQuestion(questionId, (q) => ({ ...q, puntos: 0 }));
+    } else if (!normalized.endsWith(".")) {
+      updateQuestion(questionId, (q) => ({
+        ...q,
+        puntos: parsePuntosInput(value),
+      }));
+    }
+
     setPuntosError("");
     clearQuestionError(questionId, "puntos");
+  };
+
+  const commitQuestionPuntos = (questionId: string) => {
+    const draft = puntosDraft[questionId];
+    const puntos =
+      draft !== undefined ? parsePuntosInput(draft) : undefined;
+    if (puntos !== undefined) {
+      updateQuestion(questionId, (q) => ({ ...q, puntos }));
+    }
+    setPuntosDraft((prev) => {
+      const next = { ...prev };
+      delete next[questionId];
+      return next;
+    });
   };
 
   const addOption = (questionId: string) => {
@@ -377,9 +415,9 @@ export default function CreateExam() {
       }
     });
 
-    if (totalPuntos !== PUNTOS_TOTAL_EXAMEN) {
+    if (!puntosSumEqualsTotal(totalPuntos)) {
       setPuntosError(
-        `La suma de puntos debe ser ${PUNTOS_TOTAL_EXAMEN} (actual: ${totalPuntos})`
+        `La suma de puntos debe ser ${PUNTOS_TOTAL_EXAMEN} (actual: ${roundPuntos(totalPuntos)})`
       );
       markInvalid("puntos-total");
     }
@@ -406,7 +444,7 @@ export default function CreateExam() {
       preguntas: questions.map((q) => ({
         id: q.id,
         texto: q.texto.trim(),
-        puntos: q.puntos,
+        puntos: roundPuntos(q.puntos),
         respuestas: q.respuestas.map((r) => ({
             id: r.id,
             texto: r.texto.trim(),
@@ -522,11 +560,19 @@ export default function CreateExam() {
                 min={1}
                 max={480}
                 step={1}
-                value={duracionMinutos}
+                value={duracionMinutos === 0 ? "" : duracionMinutos}
                 onChange={(e) => {
-                  const value = Number(e.target.value);
-                  setDuracionMinutos(Number.isNaN(value) ? 0 : value);
-                  if (duracionError) setDuracionError("");
+                  const raw = e.target.value;
+                  if (raw === "") {
+                    setDuracionMinutos(0);
+                    if (duracionError) setDuracionError("");
+                    return;
+                  }
+                  const value = Number.parseInt(raw, 10);
+                  if (!Number.isNaN(value)) {
+                    setDuracionMinutos(value);
+                    if (duracionError) setDuracionError("");
+                  }
                 }}
               />
               <p className="text-xs text-muted-foreground">
@@ -576,14 +622,16 @@ export default function CreateExam() {
                           </Label>
                           <Input
                             id={`puntos-${question.id}`}
-                            type="number"
-                            min={1}
-                            max={100}
-                            className="w-20 h-8"
-                            value={question.puntos}
+                            type="text"
+                            inputMode="decimal"
+                            className="w-24 h-8"
+                            value={
+                              puntosDraft[question.id] ?? String(question.puntos)
+                            }
                             onChange={(e) =>
                               updateQuestionPuntos(question.id, e.target.value)
                             }
+                            onBlur={() => commitQuestionPuntos(question.id)}
                           />
                         </div>
                         <Button

--- a/src/utils/examPoints.ts
+++ b/src/utils/examPoints.ts
@@ -1,35 +1,62 @@
 export const PUNTOS_TOTAL_EXAMEN = 100;
 
-/** Reparte 100 puntos en partes enteras lo más equitativas posible. */
+/** Redondea puntos a 2 decimales (centésimas). */
+export const roundPuntos = (value: number): number =>
+  Math.round(value * 100) / 100;
+
+/** True si la suma (con 2 decimales) alcanza el total del examen. */
+export const puntosSumEqualsTotal = (sum: number): boolean =>
+  roundPuntos(sum) === PUNTOS_TOTAL_EXAMEN;
+
+/**
+ * Reparte 100 puntos en partes lo más equitativas posible, con hasta 2 decimales.
+ * Ej.: 3 preguntas → [33.34, 33.33, 33.33]
+ */
 export const distributePuntosEqually = (count: number): number[] => {
   if (count <= 0) return [];
-  const base = Math.floor(PUNTOS_TOTAL_EXAMEN / count);
-  const remainder = PUNTOS_TOTAL_EXAMEN - base * count;
+
+  const totalCents = Math.round(PUNTOS_TOTAL_EXAMEN * 100);
+  const baseCents = Math.floor(totalCents / count);
+  const remainder = totalCents - baseCents * count;
+
   return Array.from({ length: count }, (_, index) =>
-    base + (index < remainder ? 1 : 0)
+    roundPuntos((baseCents + (index < remainder ? 1 : 0)) / 100)
   );
 };
 
 export const sumPreguntasPuntos = (
   preguntas: Array<{ puntos?: number }>
 ): number =>
-  preguntas.reduce((acc, pregunta) => acc + (pregunta.puntos ?? 0), 0);
+  roundPuntos(
+    preguntas.reduce((acc, pregunta) => acc + (pregunta.puntos ?? 0), 0)
+  );
 
 export const sumPreguntasPuntosObtenidos = (
   preguntas: Array<{ puntosObtenidos?: number; acertada?: boolean; puntos?: number }>
 ): number =>
-  preguntas.reduce((acc, pregunta) => {
-    if (typeof pregunta.puntosObtenidos === "number") {
-      return acc + pregunta.puntosObtenidos;
-    }
-    if (pregunta.acertada && typeof pregunta.puntos === "number") {
-      return acc + pregunta.puntos;
-    }
-    return acc;
-  }, 0);
+  roundPuntos(
+    preguntas.reduce((acc, pregunta) => {
+      if (typeof pregunta.puntosObtenidos === "number") {
+        return acc + pregunta.puntosObtenidos;
+      }
+      if (pregunta.acertada && typeof pregunta.puntos === "number") {
+        return acc + pregunta.puntos;
+      }
+      return acc;
+    }, 0)
+  );
 
 export const computePorcentajeFromPuntos = (puntosObtenidos: number): number =>
   Math.round(((puntosObtenidos / PUNTOS_TOTAL_EXAMEN) * 100) * 10) / 10;
 
 export const computeNotaFromPorcentaje = (porcentaje: number): number =>
   Math.round((porcentaje / 10) * 10) / 10;
+
+/** Parsea input de puntos (acepta punto o coma). */
+export const parsePuntosInput = (value: string): number => {
+  const normalized = value.replace(",", ".").trim();
+  if (normalized === "" || normalized === ".") return 0;
+  const parsed = Number.parseFloat(normalized);
+  if (Number.isNaN(parsed)) return 0;
+  return Math.max(0, Math.min(PUNTOS_TOTAL_EXAMEN, roundPuntos(parsed)));
+};


### PR DESCRIPTION
Ticket: EPEFI-140

## Qué y por qué

Los puntos del examen solo admitían enteros (34/33/33) y el input no dejaba escribir decimales; además, al borrar la duración quedaba un 0 que armaba valores como 02. Ahora la distribución equitativa usa 2 decimales (sumando 100), el campo de puntos acepta punto/coma, y la duración vacía se muestra vacía para poder tipear limpio.

## Qué puede romper

no romperia 

## Capturas
<img width="1522" height="818" alt="image" src="https://github.com/user-attachments/assets/a4a3b3a3-6257-4006-9dea-0b404aacfd55" />

<!-- Capturas de la UI si es el cambio fue en el frontend. Si es backend: el response, el log o la query con su resultado. -->
