### PR TITLE
[FIX]EPEFI-142:Se arregla distribucion forzada de puntos al agregar p…

### DIFF
--- a/src/pages/CreateExam.tsx
+++ b/src/pages/CreateExam.tsx
@@ -233,7 +233,10 @@ export default function CreateExam() {
 
   const addQuestion = () => {
     scrollToNewQuestion.current = true;
-    setQuestions((prev) => applyEqualPuntos([...prev, createEmptyQuestion()]));
+    setQuestions((prev) => [
+      ...prev,
+      { ...createEmptyQuestion(), puntos: 0 },
+    ]);
     setPuntosError("");
   };
 
@@ -244,7 +247,7 @@ export default function CreateExam() {
   }, [questions.length]);
 
   const removeQuestion = (questionId: string) => {
-    setQuestions((prev) => applyEqualPuntos(prev.filter((q) => q.id !== questionId)));
+    setQuestions((prev) => prev.filter((q) => q.id !== questionId));
     setPuntosError("");
     setPuntosDraft((prev) => {
       const next = { ...prev };


### PR DESCRIPTION
…reguntas

Ticket: EPEFI-142

## Qué y por qué

Agregar o borrar preguntas redistribuía los puntos solos y pisaba lo cargado a mano. Ahora solo redistribuye el botón “Distribuir equitativamente”; las nuevas preguntas entran en 0 y el resto no se toca. La suma a 100 se valida al guardar.

## Qué puede romper

Si suman mal y no apretan el botón, el guardado falla hasta corregir

## Capturas
<img width="1519" height="988" alt="image" src="https://github.com/user-attachments/assets/e269e742-fd03-47d6-81b2-86e01157355d" />

<!-- Capturas de la UI si es el cambio fue en el frontend. Si es backend: el response, el log o la query con su resultado. -->
